### PR TITLE
Fixed pointer variable going global

### DIFF
--- a/lib/cron.js
+++ b/lib/cron.js
@@ -165,7 +165,7 @@ CronTime.prototype = {
   _parseField: function(field, type, constraints) {
     var rangePattern = /(\d+?)(?:-(\d+?))?(?:\/(\d+?))?(?:,|$)/g,
     typeObj = this[type],
-    diff,
+    diff, pointer,
     low = constraints[0],
     high = constraints[1];
 


### PR DESCRIPTION
Using node-cron in a project and was writing some tests using [mocha](http://visionmedia.github.com/mocha/) which picked up the leak.
