### PR TITLE
Fix CronTime.sendAt to always return the first eligible date

### DIFF
--- a/lib/cron.js
+++ b/lib/cron.js
@@ -79,10 +79,13 @@ CronTime.prototype = {
    * get next date that matches parsed cron time
    */
   _getNextDateFrom: function(start) {
-    var date = new Date(start),
-    i = 1000;
+    var date = new time.Date(start);
+    try {
+      date.setTimezone(start.getTimezone());
+    } catch (e) {}
     
     //sanity check
+    var i = 1000;
     while(--i) {
       var diff = date - start;
       

--- a/tests/test-crontime.js
+++ b/tests/test-crontime.js
@@ -127,7 +127,7 @@ module.exports = testCase({
           var ct = new cron.CronTime('0 0 17 * * *');
           
           for (var hr = 0; hr < numHours; hr++) {
-            var start = new Date(2012, 3, 16, hr, 30, 30);
+            var start = new time.Date(2012, 3, 16, hr, 30, 30);
             var next = ct._getNextDateFrom(start);
             assert.ok(next - start < 24*60*60*1000);
             assert.ok(next > start);


### PR DESCRIPTION
This patch should handle the cases I had in mind for https://github.com/ncb000gt/node-cron/issues/30. There may still be some roll-over issue for the month/year matching, but my more generic approaches didn't get me anywhere.
