### PR TITLE
Fixes for timezone

### DIFF
--- a/lib/cron.js
+++ b/lib/cron.js
@@ -1,10 +1,8 @@
-var timeModuleFound = false;
+var CronDate = Date;
 try {
-  var time = require("time");
-  Date = time.Date;
-  timeModuleFound = true;
+  CronDate = require("time").Date;
 } catch(e) {
-  //no time module...leave Date alone. :)
+  //no time module...leave CronDate alone. :)
 }
 
 
@@ -19,8 +17,8 @@ function CronTime(source, zone) {
   this.dayOfMonth = {};
   this.month      = {};
 
-  if (this.source instanceof Date) {
-    this.source = new Date(this.source);
+  if ((this.source instanceof Date) || (this.source instanceof CronDate)) {
+    this.source = new CronDate(this.source);
     this.realDate = true;
   } else {
     this._parse();
@@ -40,7 +38,7 @@ CronTime.prototype = {
    * calculates the next send time
    */
   sendAt: function() {
-    var date = (this.source instanceof Date) ? this.source : new Date();
+    var date = (this.source instanceof CronDate) ? this.source : new CronDate();
     if (this.zone && date.setTimezone)
       date.setTimezone(this.zone);
     
@@ -57,7 +55,7 @@ CronTime.prototype = {
    * Get the number of seconds in the future at which to fire our callbacks.
    */
   getTimeout: function() {
-    return Math.max(-1, this.sendAt().getTime() - Date.now());
+    return Math.max(-1, this.sendAt().getTime() - CronDate.now());
   },
 
   /** 
@@ -85,7 +83,7 @@ CronTime.prototype = {
    * get next date that matches parsed cron time
    */
   _getNextDateFrom: function(start) {
-    var date = new Date(start);
+    var date = new CronDate(start);
     if (this.zone && date.setTimezone)
       date.setTimezone(start.getTimezone());
     
@@ -237,8 +235,9 @@ function CronJob(cronTime, onTick, onComplete, start, timeZone) {
     start = cronTime.start;
     cronTime = cronTime.cronTime;
     timeZone = cronTime.timeZone;
-    if (timeZone && !(Date.setTimezone)) console.log('You specified a Timezone but have not included the `time` module. Timezone functionality is disabled. Please install the `time` module to use Timezones in your application.');
   }
+
+  if (timeZone && !(CronDate.prototype.setTimezone)) console.log('You specified a Timezone but have not included the `time` module. Timezone functionality is disabled. Please install the `time` module to use Timezones in your application.');
 
   this._callbacks = [];
   this.onComplete = onComplete;

--- a/tests/test-cron.js
+++ b/tests/test-cron.js
@@ -211,23 +211,28 @@ module.exports = testCase({
     var zone = "America/Chicago";
 
     // New Orleans time
-    var d = new time.Date();
-    d.setTimezone(zone);
+    var t = new time.Date();
+    t.setTimezone(zone);
 
     // Current time
-    t = new time.Date();
-    t.setTimezone("America/New_York");
+    d = new Date();
 
     // If current time is New Orleans time, switch to Los Angeles..
     if (t.getHours() === d.getHours()) {
       zone = "America/Los_Angeles";
-      d.setTimezone(zone);
+      t.setTimezone(zone);
     }
     assert.notEqual(d.getHours(), t.getHours());
-    assert.notEqual(d.getTimezone(), t.getTimezone());
+    assert.ok(!(Date instanceof time.Date));
 
-    var seconds = d.getSeconds() + 1;
-    var c = new cron.CronJob(seconds + ' ' + d.getMinutes() + ' ' + d.getHours() +  ' * * *', function(){
+    // If t = 59s12m then t.setSeconds(60)
+    // becones 00s13m so we're fine just doing
+    // this and no testRun callback.
+    t.setSeconds(t.getSeconds()+1);
+    // Run a job designed to be executed at a given 
+    // time in `zone`, making sure that it is a different
+    // hour than local time.
+    var c = new cron.CronJob(t.getSeconds() + ' ' + t.getMinutes() + ' ' + t.getHours() +  ' * * *', function(){
       assert.ok(true);
     }, undefined, true, zone);
 
@@ -237,42 +242,33 @@ module.exports = testCase({
     }, 1250);
   },
   'test a job with a date and a given time zone': function (assert) {
-    assert.expect(2);
+    assert.expect(3);
 
     var time = require("time");
     var zone = "America/Chicago";
 
     // New Orleans time
-    var d = new time.Date();
-    d.setTimezone(zone);
+    var t = new time.Date();
+    t.setTimezone(zone);
 
     // Current time
-    t = new time.Date();
-    t.setTimezone("America/New_York");
+    d = new Date();
 
     // If current time is New Orleans time, switch to Los Angeles..
     if (t.getHours() === d.getHours()) {
       zone = "America/Los_Angeles";
-      d.setTimezone(zone);
+      t.setTimezone(zone);
     }
     assert.notEqual(d.getHours(), t.getHours());
+    assert.ok(!(Date instanceof time.Date));
 
-    if ((58 - t.getSeconds()) <= 0) {
-      setTimeout(testRun, (60000 - (t.getSeconds()*1000)) + 1000);
-    } else {
-      testRun();
-    }
-
-    function testRun() {
-      var s = d.getSeconds()+1;
-      d.setSeconds(s);
-      var c = new cron.CronJob(d, function() {
-        assert.ok(true);
-      }, null, true, zone);
-      setTimeout(function() {
-        c.stop();
-        assert.done();
-      }, 2250);
-    }
+    t.setSeconds(t.getSeconds()+1);
+    var c = new cron.CronJob(t, function() {
+      assert.ok(true);
+    }, null, true, zone);
+    setTimeout(function() {
+      c.stop();
+      assert.done();
+    }, 2250);
   }
 });


### PR DESCRIPTION
Hi,

There are a couple of issues with the previous release and making time module optional.

The most important is that it is not a good idea to modify the global `Date` constructor. See for instance:

```
> d = new Date
Wed, 25 Apr 2012 04:52:27 GMT
> cron = require("cron")
(...)
> new cron.CronJob(d, function () {})
TypeError: Object Tue Apr 24 2012 23:52:27 GMT-0500 (CDT) has no method 'replace'
    at Object._parse (/Users/toots/sources/audiosocket/origin/node_modules/cron/lib/cron.js:174:26)
    at Object.CronTime (/Users/toots/sources/audiosocket/origin/node_modules/cron/lib/cron.js:26:10)
    (...)
```

The problem here is that `Date` has been modified when requiring the `cron` module, so `d` is not detected with the right `instanceof` and assumed to be a string..

Instead, it is better to define a local `CronDate` constructor and to stick to it internally, making sure that all dates are converted to it..

There were also a couple of minor things with the test that I have changed and commented in the code..
