### PR TITLE
Fixed a bug whereby invalid syntax was accepted.

### DIFF
--- a/lib/cron.js
+++ b/lib/cron.js
@@ -179,9 +179,9 @@ CronTime.prototype = {
 
       throw new Error('Unknown alias: ' + alias);
     }),
-    split = source.replace(/^\s\s*|\s\s*$/g, '').split(/\s+/),
+    split = source.replace(/^\s\s*|\s\s*$/g, '').split(/\s+/), 
     cur, i = 0, len = CronTime.map.length;
-
+ 
     for (; i < CronTime.map.length; i++) {
       // If the split source string doesn't contain all digits, 
       // assume defaults for first n missing digits.
@@ -194,8 +194,10 @@ CronTime.prototype = {
   /**
    * Parse a field from the cron syntax.
    */
-  _parseField: function(field, type, constraints) {
-    var rangePattern = /(\d+?)(?:-(\d+?))?(?:\/(\d+?))?(?:,|$)/g,
+  _parseField: function(field, type, constraints){ 
+    
+    //var rangePattern = /^(\*)(?:\/(\d+))?$|(\d+)(?:-(\d+))?(?:\/(\d+))?(?:,|$)/g
+    var rangePattern = /^(\d+)(?:-(\d+))?(?:\/(\d+))?$/g,
     typeObj = this[type],
     diff, pointer,
     low = constraints[0],
@@ -203,29 +205,33 @@ CronTime.prototype = {
 
     // * is a shortcut to [lower-upper] range
     field = field.replace(/\*/g,  low + '-' + high);
+   
+    //commas separate information, so split based on those 
+    var allRanges = field.split(',');
 
-    if (field.match(rangePattern)) {
-      field.replace(rangePattern, function($0, lower, upper, step) {
-                      step = parseInt(step) || 1;
+    for(var i = 0; i < allRanges.length; i++){
+      if (allRanges[i].match(rangePattern)) {
+        allRanges[i].replace(rangePattern, function($0, lower, upper, step) {
+          step = parseInt(step) || 1;
+          // Positive integer higher than constraints[0]
+          lower = Math.max(low, ~~Math.abs(lower));
 
-                      // Positive integer higher than constraints[0]
-                      lower = Math.max(low, ~~Math.abs(lower));
+          // Positive integer lower than constraints[1]
+          upper = upper ? Math.min(high, ~~Math.abs(upper)) : lower;
+                        
+          // Count from the lower barrier to the upper
+          pointer = lower;
 
-                      // Positive integer lower than constraints[1]
-                      upper = upper ? Math.min(high, ~~Math.abs(upper)) : lower;
+         do {
+          typeObj[pointer] = true
+          pointer += step;
+         }while(pointer <= upper);
 
-                      // Count from the lower barrier to the upper
-                      pointer = lower;
-
-                      do {
-                          typeObj[pointer] = true
-                          pointer += step;
-                      } while(pointer <= upper);
-
-                    });
-    } else {
-      throw new Error('Field (' + field + ') cannot be parsed');
-    }
+     });
+     } else {
+        throw new Error('Field (' + field + ') cannot be parsed');
+       }
+    } 
   }
 };
 

--- a/tests/test-crontime.js
+++ b/tests/test-crontime.js
@@ -148,5 +148,11 @@ module.exports = testCase({
             assert.ok(next > start);
           }
           assert.done();
-        }
+        },
+        'test illegal repetition syntax': function(assert){
+          assert.throws(function(){
+            new cron.CronTime('* * /4 * * *');
+          });
+          assert.done();
+	      }
 });


### PR DESCRIPTION
As noted in issue #50, CronTime was accepting "\* \* \* /4 \* _" as legal syntax when the correct syntax should be "_ \* \* */4 \* *".  This commit raises an error if the user inputs invalid syntax.
