### PR TITLE
exposed the nextDate method for the CronJob prototype

### DIFF
--- a/lib/cron.js
+++ b/lib/cron.js
@@ -324,7 +324,13 @@ CronJob.prototype = {
     this.cronTime = time;
   },
 
-
+ /**
+  * Return the next scheduled date for a job
+  */
+  nextDate: function() {
+      return this.cronTime.sendAt();
+  },
+  
   /**
    * Start the cronjob.
    */


### PR DESCRIPTION
In our project we needed to know the next execution time for a job, this pull request just expose an already existing functionality.
