### PR TITLE
Reschedule onTick if time was ajusted back GH-249

### DIFF
--- a/lib/cron.js
+++ b/lib/cron.js
@@ -428,13 +428,30 @@ var start = function() {
 	var self = this;
 	var timeout = this.cronTime.getTimeout();
 	var remaining = 0;
+	var startTime;
 
 	if (this.cronTime.realDate) this.runOnce = true;
+
+	function _setTimeout(timeout) {
+		startTime = Date.now();
+		self._timeout = setTimeout(callbackWrapper, timeout);
+	}
 
 	// The callback wrapper checks if it needs to sleep another period or not
 	// and does the real callback logic when it's time.
 
 	function callbackWrapper() {
+		var diff = startTime + timeout - Date.now();
+
+		if (diff > 0) {
+			var newTimeout = self.cronTime.getTimeout();
+
+			if (newTimeout > diff) {
+				newTimeout = diff;
+			}
+
+			remaining += newTimeout;
+		}
 
 		// If there is sleep time remaining, calculate how long and go to sleep
 		// again. This processing might make us miss the deadline by a few ms
@@ -451,7 +468,7 @@ var start = function() {
 				remaining = 0;
 			}
 
-			self._timeout = setTimeout(callbackWrapper, timeout);
+			_setTimeout(timeout);
 		} else {
 
 			// We have arrived at the correct point in time.
@@ -477,7 +494,7 @@ var start = function() {
 			timeout = MAXDELAY;
 		}
 
-		this._timeout = setTimeout(callbackWrapper, timeout);
+		_setTimeout(timeout);
 	} else {
 		this.stop();
 	}

--- a/tests/test-cron.js
+++ b/tests/test-cron.js
@@ -543,5 +543,20 @@ describe('cron', function() {
 		expect(c).to.eql(3);
 	});
 
+	it('should not fire if time was adjusted back', function() {
+		var c = 0;
+		var clock = sinon.useFakeTimers('setTimeout');
+
+		var job = new cron.CronJob('0 * * * * *', function() {
+			c++;
+		}, null, true);
+
+		clock.tick(60000);
+		expect(c).to.eql(0);
+
+		clock.restore();
+		job.stop();
+	});
+
 	it('should run every second monday');
 });


### PR DESCRIPTION
This patch prevents onTick() to be called twice if setTimeout callback was called earlier than expected due to time adjustment. It just measures how much time passed since we set timeout and if it's less than it should it reschedules onTick call. 