### PR TITLE
Misc style consistency improvements

### DIFF
--- a/lib/cron.js
+++ b/lib/cron.js
@@ -24,7 +24,7 @@ function CronTime(source, zone) {
 	}
 
 	var that = this;
-	timeUnits.map(function(timeUnit){
+	timeUnits.map(function(timeUnit) {
 		that[timeUnit] = {};
 	});
 
@@ -47,7 +47,7 @@ CronTime.constraints = [
 	];
 	CronTime.monthConstraints = [
 		31,
-		29, //support leap year...not perfect
+		29, // Support leap year...not perfect
 		31,
 		30,
 		31,
@@ -115,29 +115,29 @@ CronTime.prototype = {
 		if (this.realDate)
 			return date;
 
-		//add 1 second so next time isn't now (can cause timeout to be 0 or negative number)
+		// Add 1 second so next time isn't now (can cause timeout to be 0 or negative number)
 		var now = new Date();
 		var targetSecond = date.seconds();
-		var diff = Math.abs(targetSecond - now.getSeconds())
-		// there was a problem when `date` is 1424777177999 and `now` is 1424777178000
+		var diff = Math.abs(targetSecond - now.getSeconds());
+		// There was a problem when `date` is 1424777177999 and `now` is 1424777178000
 		// 1 ms diff but this is another second...
 		if ( diff == 0 || (diff == 1 && now.getMilliseconds() <= date.milliseconds() ) ) {
 			//console.log('add 1 second?');
 			date = date.add(1, 's');
 		}
 
-		//If the i argument is not given, return the next send time
-		if(isNaN(i) || i < 0){
+		// If the i argument is not given, return the next send time
+		if (isNaN(i) || i < 0) {
 			date = this._getNextDateFrom(date);
 			return date;
 		}
-		//Else return the next i send times
-		else{
+		// Else return the next i send times
+		else {
 			var dates = [];
-			for(;i>0;i--){
+			for (; i > 0; i--) {
 				date = this._getNextDateFrom(date);
 				dates.push(moment(date));
-				if(i>1) date.add(1,'s');
+				if (i > 1) date.add(1,'s');
 			}
 			return dates;
 		}
@@ -162,7 +162,7 @@ CronTime.prototype = {
 	 */
 	toJSON: function() {
 		var self = this;
-		return timeUnits.map(function(timeName){
+		return timeUnits.map(function(timeName) {
 			return self._wcOrAll(timeName);
 		});
 	},
@@ -180,7 +180,7 @@ CronTime.prototype = {
 			console.log('WARNING: Date in past. Will never be fired.');
 		if (this.realDate) return date;
 
-		//sanity check
+		// Sanity check
 		while (true) {
 			var diff = date - start,
 				origDate = new Date(date);
@@ -226,7 +226,7 @@ CronTime.prototype = {
 
 			if (!(date.minutes() in this.minute)) {
 				origDate = moment(date);
-				date.minutes(date.minutes() == 59 && diff > 60 * 60 * 1000 ? 0 : date.minutes() + 1);
+				date.minutes(date.minutes() == 59 && diff > 3600000 ? 0 : date.minutes() + 1);
 				date.seconds(0);
 				if (date <= origDate) {
 					date = this._findDST(origDate);
@@ -236,7 +236,7 @@ CronTime.prototype = {
 
 			if (!(date.seconds() in this.second)) {
 				origDate = moment(date);
-				date.seconds(date.seconds() == 59 && diff > 60 * 1000 ? 0 : date.seconds() + 1);
+				date.seconds(date.seconds() == 59 && diff > 60000 ? 0 : date.seconds() + 1);
 				if (date <= origDate) {
 					date = this._findDST(origDate);
 				}
@@ -284,7 +284,6 @@ CronTime.prototype = {
 		return true;
 	},
 
-
 	_parse: function() {
 		var aliases = CronTime.aliases,
 		source = this.source.replace(/[a-z]{1,3}/ig, function(alias) {
@@ -296,7 +295,7 @@ CronTime.prototype = {
 
 			throw new Error('Unknown alias: ' + alias);
 		}),
-		split = source.replace(/^\s\s*|\s\s*$/g, '').split(/\s+/),
+		split = source.replace(/^\s+|\s+$/g, '').split(/\s+/),
 		cur, i = 0,
 		len = timeUnits.length;
 
@@ -319,7 +318,7 @@ CronTime.prototype = {
 		// * is a shortcut to [lower-upper] range
 		field = field.replace(/\*/g, low + '-' + high);
 
-		//commas separate information, so split based on those
+		// Commas separate information, so split based on those
 		var allRanges = field.split(',');
 
 		for (var i = 0; i < allRanges.length; i++) {
@@ -336,7 +335,7 @@ CronTime.prototype = {
 					pointer = lower;
 
 					do {
-						typeObj[pointer] = true
+						typeObj[pointer] = true;
 						pointer += step;
 					} while (pointer <= upper);
 				});
@@ -367,13 +366,13 @@ function command2function(cmd) {
 			break;
 	}
 
-	return cmd
+	return cmd;
 }
 
 function CronJob(cronTime, onTick, onComplete, startNow, timeZone, context, runOnInit) {
 	var _cronTime = cronTime;
 	if (typeof cronTime != 'string' && arguments.length == 1) {
-		//crontime is an object...
+		// Crontime is an object...
 		onTick = cronTime.onTick;
 		onComplete = cronTime.onComplete;
 		context = cronTime.context;
@@ -458,7 +457,7 @@ var start = function() {
 
 			self.running = false;
 
-			//start before calling back so the callbacks have the ability to stop the cron job
+			// Start before calling back so the callbacks have the ability to stop the cron job
 			if (!(self.runOnce)) self.start();
 
 			self.fireOnTick();
@@ -485,7 +484,7 @@ var start = function() {
 
 CronJob.prototype.start = start;
 
-CronJob.prototype.lastDate = function(){
+CronJob.prototype.lastDate = function() {
 	return this.lastExecution;
 };
 


### PR DESCRIPTION
There are various code style inconsistencies in the lib. This PR aims to fix some of them. There's no functional change.

I'm not sure the PR is welcome, so feel free to throw it away.

Looking at the majority of the code I reckoned the following rule were "more standard" in the codebase:
* single line comments are `//<space><capital_letter>...`
* semi-colon everywhere
* space before `{` for function/if/else/loops
* space after if/else
* spaces in for loop definitions

One probably contentious change I made: I precomputed the second and minutes constants to match the way it was done for the "hours" block.

And finally, a minor fix on the regex trim: `/^\s\s*|\s\s*$/g` can be simplified to `/^\s+|\s+$/g`.

Cheers.
