### PR TITLE
Add example for job.running in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,40 @@ try {
 ```
 
 
+How to check if a job is running
+==========
+
+```javascript
+var cron = require('cron');
+
+var job1 = new cron.CronJob({
+  cronTime: '* * * * *',
+  onTick: function() {
+    console.log('job 1 ticked');
+  },
+  start: false,
+  timeZone: 'America/Los_Angeles'
+});
+
+var job2 = new cron.CronJob({
+  cronTime: '* * * * *',
+  onTick: function() {
+    console.log('job 2 ticked');
+  },
+  start: false,
+  timeZone: 'America/Los_Angeles'
+});
+
+console.log('job1 status', job1.running); // job1 status undefined
+console.log('job2 status', job2.running); // job2 status undefined
+
+job1.start(); // job 1 started
+
+console.log('job1 status', job1.running); // job1 status true
+console.log('job2 status', job2.running); // job2 status undefined
+```
+
+
 Install
 ==========
 


### PR DESCRIPTION
The job.running variable can be used to get status of job, but have to use a slightly modified syntax
This PR addresses https://github.com/kelektiv/node-cron/issues/265

Hi,
This is my first time creating a documentation related PR. Please let me know, if I can make any improvements on this