### PR TITLE
Add full names of months & week days to aliases

### DIFF
--- a/lib/cron.js
+++ b/lib/cron.js
@@ -79,7 +79,25 @@ CronTime.constraints = [
 		wed: 3,
 		thu: 4,
 		fri: 5,
-		sat: 6
+		sat: 6,
+        sunday: 0,
+        monday: 1,
+        tuesday: 2,
+        wednesday: 3,
+        thursday: 4,
+        friday: 5,
+        saturday: 6,
+        january: 0,
+        february: 1,
+        march: 2,
+        april: 3,
+        june: 5,
+        july: 6,
+        august: 7,
+        september: 8,
+        october: 9,
+        november: 10,
+        december: 11
 	};
 
 


### PR DESCRIPTION
According to specification : http://crontab.org/
# day of week    0-7 (0 or 7 is Sun, or _USE NAMES_)