### PR TITLE
Match exports.job() signature to CronJob constructor

### DIFF
--- a/lib/cron.js
+++ b/lib/cron.js
@@ -516,8 +516,8 @@ CronJob.prototype.stop = function() {
 	if (typeof this.onComplete == 'function') this.onComplete();
 }
 
-exports.job = function(cronTime, onTick, onComplete) {
-	return new CronJob(cronTime, onTick, onComplete);
+exports.job = function(cronTime, onTick, onComplete, startNow, timeZone, context, runOnInit) {
+	return new CronJob(cronTime, onTick, onComplete, startNow, timeZone, context, runOnInit);
 }
 
 exports.time = function(cronTime, timeZone) {


### PR DESCRIPTION
Update undocumented `exports.job()` function to accept and pass all the arguments in the `CronJob` object's constructor function.

By the way, I prefer calling `cron.job()` over instantiating a `new CronJob()` manually. One reason is that it plays nicer with [this ESLint rule](http://eslint.org/docs/rules/no-new) when I don't need to store the job in a variable. Is there a reason `cron.job()` is undocumented, or should it be added to the docs as an alternate syntax? I'd be happy to help in that case.