### PR TITLE
Do not keep an otherwise finished program running.

### DIFF
--- a/lib/cron.js
+++ b/lib/cron.js
@@ -463,6 +463,9 @@
 		function _setTimeout(timeout) {
 			startTime = Date.now();
 			self._timeout = setTimeout(callbackWrapper, timeout);
+			if (typeof self._timeout.unref === 'function') {
+				self._timeout.unref()
+			}
 		}
 
 		// The callback wrapper checks if it needs to sleep another period or not


### PR DESCRIPTION
Check the .unref() method exists and call it each
time the timer is started.