### PR TITLE
fix issue when cronTime _getNextDateFrom not calculate correctly

### DIFF
--- a/lib/cron.js
+++ b/lib/cron.js
@@ -183,6 +183,13 @@
 		 */
 		_getNextDateFrom: function(start) {
 			var date = moment(start);
+			if (!this.realDate) {
+				const milliseconds = (start.milliseconds && start.milliseconds()) || (start.getMilliseconds && start.getMilliseconds()) || 0;
+				if (milliseconds > 0) {
+					date.milliseconds(0);
+					date.seconds(date.seconds() + 1);
+				}
+			}
 
 			if (date.toString() == 'Invalid date') {
 				console.log('ERROR: You specified an invalid date.');

--- a/tests/test-crontime.js
+++ b/tests/test-crontime.js
@@ -190,4 +190,16 @@ describe('crontime', function() {
 			}).to.throw(Error);
 		});
 	});
+
+	it('should strip off millisecond', ()=>{
+		const cronTime = new cron.CronTime('0 */10 * * * *');
+		const x = cronTime._getNextDateFrom(new Date("2018-08-10T02:20:00.999Z"));
+		expect(x.toISOString()).to.equal('2018-08-10T02:30:00.000Z');
+	});
+
+	it('should strip off millisecond (2)', ()=>{
+		const cronTime = new cron.CronTime('0 */10 * * * *');
+		const x = cronTime._getNextDateFrom(new Date("2018-08-10T02:19:59.999Z"));
+		expect(x.toISOString()).to.equal('2018-08-10T02:20:00.000Z');
+	});
 });


### PR DESCRIPTION
Issue:

```js
const cron = require('cron');
const cronTime = new cron.CronTime('0 */10 * * * *');
const x = cronTime._getNextDateFrom(new Date("2018-08-10T02:20:00.009Z"))
console.log(x);
```

Observe: `x`
Expect: `x` should be `2018-08-10T02:30:00.009Z` (next 10 mins coz the cron pattern is each 10 mins)
Actual: `2018-08-10T02:20:00.009Z` (unchange).
Affect: This issue will cause `cron` to repeat triggering `onTick` many many times within one second.