### PR TITLE
fix issue when cronTime _getNextDateFrom not calculate correctly

### DIFF
--- a/lib/cron.js
+++ b/lib/cron.js
@@ -183,6 +183,13 @@
 		 */
 		_getNextDateFrom: function(start) {
 			var date = moment(start);
+			if (!this.realDate) {
+				const milliseconds = (start.milliseconds && start.milliseconds()) || (start.getMilliseconds && start.getMilliseconds()) || 0;
+				if (milliseconds > 0) {
+					date.milliseconds(0);
+					date.seconds(date.seconds() + 1);
+				}
+			}
 
 			if (date.toString() == 'Invalid date') {
 				console.log('ERROR: You specified an invalid date.');

--- a/tests/test-crontime.js
+++ b/tests/test-crontime.js
@@ -1,45 +1,45 @@
 var chai = require('chai'),
 	expect = chai.expect,
-		cron = require('../lib/cron');
+	cron = require('../lib/cron');
 
-describe('crontime', function() {
-	it('should test stars (* * * * * *)', function() {
-		expect(function() {
+describe('crontime', function () {
+	it('should test stars (* * * * * *)', function () {
+		expect(function () {
 			new cron.CronTime('* * * * * *');
 		}).to.not.throw(Error);
 	});
 
-	it('should test digit (0 * * * * *)', function() {
-		expect(function() {
+	it('should test digit (0 * * * * *)', function () {
+		expect(function () {
 			new cron.CronTime('0 * * * * *');
 		}).to.not.throw(Error);
 	});
 
-	it('should test multi digits (08 * * * * *)', function() {
-		expect(function() {
+	it('should test multi digits (08 * * * * *)', function () {
+		expect(function () {
 			new cron.CronTime('08 * * * * *');
 		}).to.not.throw(Error);
 	});
 
-	it('should test all digits (08 8 8 8 8 5)', function() {
-		expect(function() {
+	it('should test all digits (08 8 8 8 8 5)', function () {
+		expect(function () {
 			new cron.CronTime('08 * * * * *');
 		}).to.not.throw(Error);
 	});
 
-	it('should test too many digits (08 8 8 8 8 5)', function() {
-		expect(function() {
+	it('should test too many digits (08 8 8 8 8 5)', function () {
+		expect(function () {
 			new cron.CronTime('08 * * * * *');
 		}).to.not.throw(Error);
 	});
 
-	it('should test standard cron format (* * * * *)', function() {
-		expect(function() {
+	it('should test standard cron format (* * * * *)', function () {
+		expect(function () {
 			new cron.CronTime('* * * * *');
 		}).to.not.throw(Error);
 	});
 
-	it('should test standard cron format (8 8 8 8 5)', function() {
+	it('should test standard cron format (8 8 8 8 5)', function () {
 		var standard = new cron.CronTime('8 8 8 8 5');
 		var extended = new cron.CronTime('0 8 8 8 8 5');
 
@@ -51,81 +51,81 @@ describe('crontime', function() {
 		expect(standard.second).to.deep.eql(extended.second);
 	});
 
-	it('should test hyphen (0-10 * * * * *)', function() {
-		expect(function() {
+	it('should test hyphen (0-10 * * * * *)', function () {
+		expect(function () {
 			new cron.CronTime('0-10 * * * * *');
 		}).to.not.throw(Error);
 	});
 
-	it('should test multi hyphens (0-10 0-10 * * * *)', function() {
-		expect(function() {
+	it('should test multi hyphens (0-10 0-10 * * * *)', function () {
+		expect(function () {
 			new cron.CronTime('0-10 0-10 * * * *');
 		}).to.not.throw(Error);
 	});
 
-	it('should test all hyphens (0-10 0-10 0-10 0-10 0-10 0-1)', function() {
-		expect(function() {
+	it('should test all hyphens (0-10 0-10 0-10 0-10 0-10 0-1)', function () {
+		expect(function () {
 			new cron.CronTime('0-10 0-10 0-10 0-10 0-10 0-1');
 		}).to.not.throw(Error);
 	});
 
-	it('should test comma (0,10 * * * * *)', function() {
-		expect(function() {
+	it('should test comma (0,10 * * * * *)', function () {
+		expect(function () {
 			new cron.CronTime('0,10 * * * * *');
 		}).to.not.throw(Error);
 	});
 
-	it('should test multi commas (0,10 0,10 * * * *)', function() {
-		expect(function() {
+	it('should test multi commas (0,10 0,10 * * * *)', function () {
+		expect(function () {
 			new cron.CronTime('0,10 0,10 * * * *');
 		}).to.not.throw(Error);
 	});
 
-	it('should test all commas (0,10 0,10 0,10 0,10 0,10 0,1)', function() {
-		expect(function() {
+	it('should test all commas (0,10 0,10 0,10 0,10 0,10 0,1)', function () {
+		expect(function () {
 			new cron.CronTime('0,10 0,10 0,10 0,10 0,10 0,1');
 		}).to.not.throw(Error);
 	});
 
-	it('should test alias (* * * * jan *)', function() {
-		expect(function() {
+	it('should test alias (* * * * jan *)', function () {
+		expect(function () {
 			new cron.CronTime('* * * * jan *');
 		}).to.not.throw(Error);
 	});
 
-	it('should test multi aliases (* * * * jan,feb *)', function() {
-		expect(function() {
+	it('should test multi aliases (* * * * jan,feb *)', function () {
+		expect(function () {
 			new cron.CronTime('* * * * jan,feb *');
 		}).to.not.throw(Error);
 	});
 
-	it('should test all aliases (* * * * jan,feb mon,tue)', function() {
-		expect(function() {
+	it('should test all aliases (* * * * jan,feb mon,tue)', function () {
+		expect(function () {
 			new cron.CronTime('* * * * jan,feb mon,tue');
 		}).to.not.throw(Error);
 	});
 
 	it('should test every second monday (* * * * * mon/2)');
 
-	it('should test unknown alias (* * * * jar *)', function() {
-		expect(function() {
+	it('should test unknown alias (* * * * jar *)', function () {
+		expect(function () {
 			new cron.CronTime('* * * * jar *');
 		}).to.throw(Error);
 	});
 
-	it('should test unknown alias - short (* * * * j *)', function() {
-		expect(function() {
+	it('should test unknown alias - short (* * * * j *)', function () {
+		expect(function () {
 			new cron.CronTime('* * * * j *');
 		}).to.throw(Error);
 	});
 
-	it('should test Date', function() {
+	it('should test Date', function () {
 		var d = new Date();
 		var ct = new cron.CronTime(d);
 		expect(ct.source.isSame(d.getTime())).to.be.true
 	});
 
-	it('should test day roll-over', function() {
+	it('should test day roll-over', function () {
 		var numHours = 24;
 		var ct = new cron.CronTime('0 0 17 * * *');
 
@@ -133,18 +133,18 @@ describe('crontime', function() {
 			var start = new Date(2012, 3, 16, hr, 30, 30);
 			var next = ct._getNextDateFrom(start);
 
-			expect(next - start).to.be.lt(24*60*60*1000);
+			expect(next - start).to.be.lt(24 * 60 * 60 * 1000);
 			expect(next).to.be.gt(start);
 		}
 	});
 
-	it('should test illegal repetition syntax', function() {
-		expect(function(){
+	it('should test illegal repetition syntax', function () {
+		expect(function () {
 			new cron.CronTime('* * /4 * * *');
 		}).to.throw(Error);
 	});
 
-	it('should test next date', function() {
+	it('should test next date', function () {
 		var ct = new cron.CronTime('0 0 */4 * * *');
 
 		var nextDate = new Date();
@@ -155,7 +155,7 @@ describe('crontime', function() {
 		expect(nextdt.hours() % 4).to.eql(0);
 	});
 
-	it('should test next date from invalid date', function() {
+	it('should test next date from invalid date', function () {
 		var ct = new cron.CronTime('0 0 * * * *');
 		var nextDate = new Date('My invalid date string');
 		var nextdt = ct._getNextDateFrom(nextDate);
@@ -163,11 +163,11 @@ describe('crontime', function() {
 		expect(nextdt.toString()).to.eql('Invalid date');
 	});
 
-	it('should test next real date', function() {
+	it('should test next real date', function () {
 		var ct = new cron.CronTime(new Date());
 
 		var nextDate = new Date();
-		nextDate.setMonth(nextDate.getMonth()+1);
+		nextDate.setMonth(nextDate.getMonth() + 1);
 		expect(nextDate).to.be.gt(ct.source);
 		var nextdt = ct._getNextDateFrom(nextDate);
 		expect(nextdt.isSame(nextDate)).to.be.true;
@@ -175,31 +175,31 @@ describe('crontime', function() {
 
 	it('should test next month selection');
 
-	describe('should throw an exception because `L` not supported', function() {
+	describe('should throw an exception because `L` not supported', function () {
 
-		it('(* * * L * *)', function() {
-			expect(function() {
+		it('(* * * L * *)', function () {
+			expect(function () {
 				new cron.CronTime('* * * L * *');
 			}).to.throw(Error);
 
 		});
 
-		it('(* * * * * L)', function() {
-			expect(function() {
+		it('(* * * * * L)', function () {
+			expect(function () {
 				new cron.CronTime('* * * * * L');
 			}).to.throw(Error);
 		});
 	});
 
-	it('should strip off millisecond', ()=>{
-		const cronTime = new cron.CronTime('0 */10 * * * *');
-		const x = cronTime._getNextDateFrom(new Date("2018-08-10T02:20:00.999Z"));
+	it('should strip off millisecond', function () {
+		var cronTime = new cron.CronTime('0 */10 * * * *');
+		var x = cronTime._getNextDateFrom(new Date("2018-08-10T02:20:00.999Z"));
 		expect(x.toISOString()).to.equal('2018-08-10T02:30:00.000Z');
 	});
 
-	it('should strip off millisecond (2)', ()=>{
-		const cronTime = new cron.CronTime('0 */10 * * * *');
-		const x = cronTime._getNextDateFrom(new Date("2018-08-10T02:19:59.999Z"));
+	it('should strip off millisecond (2)', function () {
+		var cronTime = new cron.CronTime('0 */10 * * * *');
+		var x = cronTime._getNextDateFrom(new Date("2018-08-10T02:19:59.999Z"));
 		expect(x.toISOString()).to.equal('2018-08-10T02:20:00.000Z');
 	});
 });

--- a/tests/test-crontime.js
+++ b/tests/test-crontime.js
@@ -190,4 +190,16 @@ describe('crontime', function() {
 			}).to.throw(Error);
 		});
 	});
+
+	it('should strip off millisecond', ()=>{
+		const cronTime = new cron.CronTime('0 */10 * * * *');
+		const x = cronTime._getNextDateFrom(new Date("2018-08-10T02:20:00.999Z"));
+		expect(x.toISOString()).to.equal('2018-08-10T02:30:00.000Z');
+	});
+
+	it('should strip off millisecond (2)', ()=>{
+		const cronTime = new cron.CronTime('0 */10 * * * *');
+		const x = cronTime._getNextDateFrom(new Date("2018-08-10T02:19:59.999Z"));
+		expect(x.toISOString()).to.equal('2018-08-10T02:20:00.000Z');
+	});
 });


### PR DESCRIPTION
Issue:

```js
const cron = require('cron');
const cronTime = new cron.CronTime('0 */10 * * * *');
const x = cronTime._getNextDateFrom(new Date("2018-08-10T02:20:00.009Z"))
console.log(x);
```

Observe: `x`
Expect: `x` should be `2018-08-10T02:30:00.009Z` (next 10 mins coz the cron pattern is each 10 mins)
Actual: `2018-08-10T02:20:00.009Z` (unchange).
Affect: This issue will cause `cron` to repeat triggering `onTick` many many times within one second.