### PR TITLE
emergency fix for bug in v1.4.0

### DIFF
--- a/lib/cron.js
+++ b/lib/cron.js
@@ -101,8 +101,9 @@
 					if (dom <= con) {
 						ok = true;
 					} else {
-						delete this.dayOfMonth[j];
-						this.dayOfMonth[String(Number(dsom[j])) % con] = true;
+						var day=String(Number(dsom[j])) % con;
+						delete this.dayOfMonth[day];
+						this.dayOfMonth[day] = true;
 					}
 				}
 


### PR DESCRIPTION
Fixing bug in that  resulted from  a typo  were day of month was not converted to string `delete this.dayOfMonth[j];`
#366 #372 #371 #373 


I've just noticed most of tests have runNow attribute as true which resulted in hiding the bug.
I'm extremely sorry for the inconvenience caused.