### PR TITLE
fixing bug in version 1.4.0

### DIFF
--- a/lib/cron.js
+++ b/lib/cron.js
@@ -89,27 +89,40 @@
 	CronTime.prototype = {
 		_verifyParse: function() {
 			var months = Object.keys(this.month);
-
+			var ok = false;
+			/* if a dayOfMonth is not found in all months, we only need to fix the last
+			 wrong month  to prevent infinite loop */
+			var lastWrongMonth={};
 			for (var i = 0; i < months.length; i++) {
 				var m = months[i];
 				var con = CronTime.monthConstraints[parseInt(m, 10)];
-				var ok = false;
 				var dsom = Object.keys(this.dayOfMonth);
 
 				for (var j = 0; j < dsom.length; j++) {
 					var dom = dsom[j];
-					if (dom <= con) {
+					if (dom <= con)
 						ok = true;
-					} else {
-						delete this.dayOfMonth[j];
-						this.dayOfMonth[String(Number(dsom[j])) % con] = true;
-					}
 				}
-
 				if (!ok) {
+					// save the month inorder to be fixed if all months fails (infinite loop)
+					lastWrongMonth=m;
 					console.warn("Month '" + m + "' is limited to '" + con + "' days.");
 				}
 			}
+			// infinit loop detected (dayOfMonth is not found in all months)
+			if(!ok){
+				var con = CronTime.monthConstraints[parseInt(lastWrongMonth, 10)];
+				var dsom = Object.keys(this.dayOfMonth);
+				for (var j = 0; j < dsom.length; j++) {
+					 var dom = dsom[j];
+					 if(dom > con){
+						 delete this.dayOfMonth[dom];
+						 var fixedDay = Number(dom)% con;
+						 this.dayOfMonth[fixedDay] = true;
+					 }
+				}
+			}
+
 		},
 
 		/**


### PR DESCRIPTION

Fixing bug in that resulted from my faulty logic in my last PR. I'm extremely sorry for any inconvenience caused .

**Summary of what happened:**
My previous fix assumed that there were multiple instances of daysOfMonth for each month ( which is not valid) . This resulted in fixing the days to only match  month  February. 

Now I'm only fixing the days only if all months fail, ie: choosing day of month 45 ( not found in any month )

this will fix the following issues:
#366 #372 #371 #373 

clearly current tests were not able to detect this bug. after reviewing the current tests i realized that this was due to "start" attribute set to true such as in the first test

Again, I'm so sorry for causing this problem. 

