### PR TITLE
Accept 0 as a valid UTC offset

### DIFF
--- a/lib/cron.js
+++ b/lib/cron.js
@@ -32,7 +32,7 @@
 			this.zone = zone;
 		}
 
-		if (utcOffset) this.utcOffset = utcOffset;
+		if (typeof utcOffset !== 'undefined') this.utcOffset = utcOffset;
 
 		var that = this;
 		timeUnits.map(function(timeUnit) {
@@ -138,7 +138,7 @@
 				date = date.tz(this.zone);
 			}
 
-			if (this.utcOffset) {
+			if (typeof this.utcOffset !== 'undefined') {
 				date = date.utcOffset(this.utcOffset);
 			}
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "cron",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/tests/test-crontime.js
+++ b/tests/test-crontime.js
@@ -2,6 +2,7 @@ var chai = require('chai');
 var expect = chai.expect;
 var cron = require('../lib/cron');
 var moment = require('moment-timezone');
+var sinon = require('sinon');
 
 // most eslint errors here are due to side effects. i don't care much about them right now
 
@@ -296,5 +297,29 @@ describe('crontime', function() {
 		expect(nextDate.valueOf()).to.equal(
 			new Date(Date.UTC(2019, 1, 1, 0, 0)).valueOf()
 		);
+	});
+
+	it('should accept 0 as a valid UTC offset', function() {
+		var clock = sinon.useFakeTimers();
+
+		var cronTime = new cron.CronTime('0 11 * * *', null, 0);
+		var expected = moment().add(11, 'hours').unix();
+		var actual = cronTime.sendAt().unix();
+
+		expect(actual).to.equal(expected);
+
+		clock.restore();
+	});
+
+	it('should accept -120 as a valid UTC offset', function() {
+		var clock = sinon.useFakeTimers();
+
+		var cronTime = new cron.CronTime('0 11 * * *', null, -120);
+		var expected = moment().add(13, 'hours').unix();
+		var actual = cronTime.sendAt().unix();
+
+		expect(actual).to.equal(expected);
+
+		clock.restore();
 	});
 });


### PR DESCRIPTION
The current implementation ignores the UTC offset when it's specified as the number 0, so if you create a job using the command `new CronJob('0 16 * * *', { utcOffset: 0, start: true, ... })` at `15:59:59 GMT+2` it gets executed a second later, whereas it should actually be executed two hours later, at `18:00 GMT+2`/`16:00 UTC`.

The underlying library, moment, does accept `0`, so we only need to pass it over.

This PR replaces the naive if-based truth checks with the more restricted `undefined` checks.