### PR TITLE
Update README to note that setTime() stops the job

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,7 +165,7 @@ Parameter Based
 		from the NodeJS docs.
   * `start` - Runs your job.
   * `stop` - Stops your job.
-  * `setTime` - Change the time for the `CronJob`. Param must be a `CronTime`.
+  * `setTime` - Stops and changes the time for the `CronJob`. Param must be a `CronTime`.
   * `lastDate` - Tells you the last execution date.
   * `nextDates` - Provides an array of the next set of dates that will trigger an `onTick`.
   * `fireOnTick` - Allows you to override the `onTick` calling behavior. This


### PR DESCRIPTION
Ran into this issue recently; I had assumed that setTime() kept the job running. Had to take a look at the source code to see that the job get stopped first. A small update that clarifies things.