### PR TITLE
Range upper limit should default to highest value when step is provided

### DIFF
--- a/lib/cron.js
+++ b/lib/cron.js
@@ -454,6 +454,7 @@
 			for (var i = 0; i < allRanges.length; i++) {
 				if (allRanges[i].match(rangePattern)) {
 					allRanges[i].replace(rangePattern, function($0, lower, upper, step) {
+						const wasStepDefined = !isNaN(parseInt(step));
 						if (step === '0') {
 							throw new Error('Field (' + field + ') has a step of zero');
 						}
@@ -476,7 +477,12 @@
 						lower = Math.min(Math.max(low, ~~Math.abs(lower)), high);
 
 						// Positive integer lower than constraints[1]
-						upper = upper ? Math.min(high, ~~Math.abs(upper)) : lower;
+						if (upper) {
+							upper = Math.min(high, ~~Math.abs(upper));
+						} else {
+							// If step is provided, the default upper range is the highest value
+							upper = wasStepDefined ? high : lower;
+						}
 
 						// Count from the lower barrier to the upper
 						pointer = lower;

--- a/tests/cron.test.js
+++ b/tests/cron.test.js
@@ -145,6 +145,22 @@ describe('cron', () => {
 			clock.restore();
 		});
 
+		it('should default to full range when upper range not provided (1/2 * * * * *)', done => {
+			const callback = jest.fn();
+			const job = new cron.CronJob(
+				'1/2 * * * * *',
+				callback,
+				() => {
+					expect(callback).toHaveBeenCalledTimes(30);
+					done();
+				},
+				true
+			);
+			clock.tick(1000 * 60);
+			job.stop();
+			clock.restore();
+		});
+
 		it('should run every second (* * * * * *) using the object constructor', () => {
 			const callback = jest.fn();
 			const job = new cron.CronJob({


### PR DESCRIPTION
Resolves #449. A range with a step and no upper limit provided should default to the full range. E.g. `"1/2 * * * * *"` should be the same as `"1-59/2 * * * * *"`.