### PR TITLE
fix!: return empty array from nextDates when called without argument

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ As goes with semver, breaking backwards compatibility should be explicit in the 
 var CronJob = require('cron').CronJob;
 var job = new CronJob(
     '* * * * * *',
-    function() {
+    function () {
         console.log('You will see this message every second');
     },
     null,
@@ -125,6 +125,7 @@ Parameter Based
     - `stop` - Stops your job.
     - `setTime` - Stops and changes the time for the `CronJob`. Param must be a `CronTime`.
     - `lastDate` - Tells you the last execution date.
+    - `nextDate` - Provides the next date that will trigger an `onTick`.
     - `nextDates` - Provides an array of the next set of dates that will trigger an `onTick`.
     - `fireOnTick` - Allows you to override the `onTick` calling behavior. This matters so only do this if you have a really good reason to do so.
     - `addCallback` - Allows you to add `onTick` callbacks.

--- a/lib/job.js
+++ b/lib/job.js
@@ -106,7 +106,7 @@ function CronJob(CronTime, spawn) {
 	CJ.prototype.fireOnTick = fireOnTick;
 
 	CJ.prototype.nextDates = function (i) {
-		return this.cronTime.sendAt(i);
+		return this.cronTime.sendAt(i || 0);
 	};
 
 	const start = function () {

--- a/tests/cron.test.js
+++ b/tests/cron.test.js
@@ -991,6 +991,16 @@ describe('cron', () => {
 		clock.restore();
 	});
 
+	it('Should give an empty array', () => {
+		const callback = jest.fn();
+		const clock = sinon.useFakeTimers();
+		const job = new cron.CronJob('* * * * * *', callback);
+
+		expect(job.nextDates()).toHaveLength(0);
+
+		clock.restore();
+	});
+
 	it('should automatically setup a new timeout if we roll past the max timeout delay', () => {
 		const callback = jest.fn();
 		const clock = sinon.useFakeTimers();

--- a/tests/cron.test.js
+++ b/tests/cron.test.js
@@ -963,42 +963,44 @@ describe('cron', () => {
 		});
 	});
 
-	it('should give the next date to run at', () => {
-		const callback = jest.fn();
-		const clock = sinon.useFakeTimers();
-		const job = new cron.CronJob('* * * * * *', callback);
-		const d = Date.now();
+	describe('nextDate(s)', () => {
+		it('should give the next date to run at', () => {
+			const callback = jest.fn();
+			const clock = sinon.useFakeTimers();
+			const job = new cron.CronJob('* * * * * *', callback);
+			const d = Date.now();
 
-		expect(job.nextDate().toMillis()).toEqual(d + 1000);
+			expect(job.nextDate().toMillis()).toEqual(d + 1000);
 
-		clock.restore();
-	});
+			clock.restore();
+		});
 
-	it('should give the next dates to run at', () => {
-		const callback = jest.fn();
-		const clock = sinon.useFakeTimers();
-		const job = new cron.CronJob('* * * * * *', callback);
-		const d = Date.now();
+		it('should give the next 5 dates to run at', () => {
+			const callback = jest.fn();
+			const clock = sinon.useFakeTimers();
+			const job = new cron.CronJob('* * * * * *', callback);
+			const d = Date.now();
 
-		expect(job.nextDates(5).map(d => d.toMillis())).toEqual([
-			d + 1000,
-			d + 2000,
-			d + 3000,
-			d + 4000,
-			d + 5000
-		]);
+			expect(job.nextDates(5).map(d => d.toMillis())).toEqual([
+				d + 1000,
+				d + 2000,
+				d + 3000,
+				d + 4000,
+				d + 5000
+			]);
 
-		clock.restore();
-	});
+			clock.restore();
+		});
 
-	it('Should give an empty array', () => {
-		const callback = jest.fn();
-		const clock = sinon.useFakeTimers();
-		const job = new cron.CronJob('* * * * * *', callback);
+		it('should give an empty array when called without argument', () => {
+			const callback = jest.fn();
+			const clock = sinon.useFakeTimers();
+			const job = new cron.CronJob('* * * * * *', callback);
 
-		expect(job.nextDates()).toHaveLength(0);
+			expect(job.nextDates()).toHaveLength(0);
 
-		clock.restore();
+			clock.restore();
+		});
 	});
 
 	it('should automatically setup a new timeout if we roll past the max timeout delay', () => {


### PR DESCRIPTION
## Proposed changes

- Make sure that `nextDates` return an array(as described in the README.md) even if it's called without an argument(in this case an empty array)
- Add `nextDate` description in the README.md

## Current behaviour

- `nextDates` return a moment object, if it's called without an argument

## Details

- This change could break someone's code!!
- If this PR is not accepted, I will make another PR just to update the description of the behaviour of `nextDates` function in the READM.md
