### PR TITLE
update maximum iterations error to refer to canonical GitHub issue

### DIFF
--- a/lib/time.js
+++ b/lib/time.js
@@ -266,8 +266,8 @@ function CronTime(luxon) {
 				// hard stop if the current date is after the expected execution
 				if (Date.now() > timeout) {
 					throw new Error(
-						`Something went wrong. cron reached maximum iterations.
-							Please open an  issue (https://github.com/kelektiv/node-cron/issues/new) and provide the following string
+						`Something went wrong. It took over five seconds to find the next execution time for the cron job.
+							Please refer to the canonical issue (https://github.com/kelektiv/node-cron/issues/467) and provide the following string if you would like to help debug:
 							Time Zone: ${zone || '""'} - Cron String: ${this} - UTC offset: ${date.format(
 							'Z'
 						)} - current Date: ${luxon.DateTime.local().toString()}`


### PR DESCRIPTION
we can close the ~40 duplicate issues and people can stop creating new ones that all likely focus on the same bug. if we find there are different causes for the 5 second difference in execution we can create multiple canonical issues to address the different causes