### PR TITLE
Fix infinite looping bugs with recurrent tasks around DST

### DIFF
--- a/lib/time.js
+++ b/lib/time.js
@@ -266,7 +266,6 @@ function CronTime(luxon) {
 			// determine next date
 			while (true) {
 				var diff = date - start;
-				console.log(date.toISO());
 
 				// hard stop if the current date is after the expected execution
 				if (Date.now() > timeout) {
@@ -515,9 +514,6 @@ function CronTime(luxon) {
 				}
 			}
 
-			console.log('minute range', minuteRange);
-			console.log('hour range', hourRange);
-
 			for (const h of hourRange) {
 				if (!(h in this.hour)) continue; // hour mismatch, not a valid time.
 
@@ -568,8 +564,6 @@ function CronTime(luxon) {
 
 			const hoursJumped = expectedHour % 24 < actualHour;
 			const minutesJumped = expectedMinute % 60 < actualMinute;
-
-			console.log('hours diff? ', expectedHour, actualHour, hoursJumped);
 
 			return hoursJumped || minutesJumped;
 		},

--- a/lib/time.js
+++ b/lib/time.js
@@ -359,7 +359,7 @@ function CronTime(luxon) {
 				) {
 					const expectedMinute =
 						date.minute === 59 && diff > 3600000 ? 0 : date.minute + 1;
-					const expectedHour = date.hour + (expectedMinute === 60);
+					const expectedHour = date.hour + (expectedMinute === 60 ? 1 : 0);
 
 					date = date.set({ minute: expectedMinute });
 					date = date.set({ second: 0 });
@@ -382,7 +382,7 @@ function CronTime(luxon) {
 					const expectedSecond =
 						date.second === 59 && diff > 60000 ? 0 : date.second + 1;
 					const expectedMinute = date.minute + (expectedSecond === 60);
-					const expectedHour = date.hour + (expectedMinute === 60);
+					const expectedHour = date.hour + (expectedMinute === 60 ? 1 : 0);
 
 					date = date.set({ second: expectedSecond });
 
@@ -399,7 +399,7 @@ function CronTime(luxon) {
 				if (date.toMillis() === firstDate) {
 					const expectedSecond = date.second + 1;
 					const expectedMinute = date.minute + (expectedSecond === 60);
-					const expectedHour = date.hour + (expectedMinute === 60);
+					const expectedHour = date.hour + (expectedMinute === 60 ? 1 : 0);
 
 					date = date.set({ second: expectedSecond });
 

--- a/lib/time.js
+++ b/lib/time.js
@@ -536,6 +536,14 @@ function CronTime(luxon) {
 		/**
 		 * Component of checking if a CronJob time existed in a DateTime range skipped by DST.
 		 * This subroutine assumes the jump touches at least 2 hours, but the jump does not necessarily fully contain these hours.
+		 *
+		 * @see _checkTimeInSkippedRange
+		 *
+		 * This is done by defining the minutes to check for the first and last hour,
+		 * and checking all 60 minutes for any hours in between them.
+		 *
+		 * If any hour x minute combination is a valid time, true is returned.
+		 * The endMinute x endHour combination is only checked with the 0th second, since the rest would be out of the range.
 		 */
 		_checkTimeInSkippedRangeMultiHour: function (
 			startMinute,

--- a/lib/time.js
+++ b/lib/time.js
@@ -266,7 +266,6 @@ function CronTime(luxon) {
 			// determine next date
 			while (true) {
 				var diff = date - start;
-				console.log(date.toISO());
 
 				// hard stop if the current date is after the expected execution
 				if (Date.now() > timeout) {
@@ -650,8 +649,6 @@ function CronTime(luxon) {
 
 			const hoursJumped = expectedHour % 24 < actualHour;
 			const minutesJumped = expectedMinute % 60 < actualMinute;
-
-			console.log('hours diff? ', expectedHour, actualHour, hoursJumped);
 
 			return hoursJumped || minutesJumped;
 		},

--- a/lib/time.js
+++ b/lib/time.js
@@ -433,25 +433,27 @@ function CronTime(luxon) {
 			/** @type number */
 			let expectedMinute, expectedHour, actualMinute, actualHour;
 			/** @type DateTime */
-			let maybeJumpingPoint;
+			let maybeJumpingPoint = date;
 
 			// representing one day of backwards checking. If this is hit, the input must be wrong.
 			const iterationLimit = 60 * 24;
 			let iteration = 0;
 			do {
-				if (iteration++ > iterationLimit) {
+				if (++iteration > iterationLimit) {
 					throw new Error(
 						`ERROR: This DST checking related function assumes the input DateTime (${date.toISO()}) is within 24 hours of a DST jump.`
 					);
 				}
 
-				expectedMinute = date.minute - 1;
-				expectedHour = date.hour - 1;
+				expectedMinute = maybeJumpingPoint.minute - 1;
+				expectedHour = maybeJumpingPoint.hour;
 
-				if (expectedMinute < 0) expectedMinute += 60;
-				if (expectedHour < 0) expectedHour += 60;
+				if (expectedMinute < 0) {
+					expectedMinute += 60;
+					expectedHour = (expectedHour + 24 - 1) % 24; // Subtract 1 hour, but we must account for the -1 case.
+				}
 
-				maybeJumpingPoint = date.minus({ minute: 1 });
+				maybeJumpingPoint = maybeJumpingPoint.minus({ minute: 1 });
 
 				actualMinute = maybeJumpingPoint.minute;
 				actualHour = maybeJumpingPoint.hour;

--- a/lib/time.js
+++ b/lib/time.js
@@ -478,79 +478,118 @@ function CronTime(luxon) {
 		 * @returns {boolean}
 		 */
 		_checkTimeInSkippedRange: function (beforeJumpingPoint, afterJumpingPoint) {
-			// start by getting the first minute inside the skipped range.
+			// start by getting the first minute & hour inside the skipped range.
 			const startingMinute = (beforeJumpingPoint.minute + 1) % 60;
 			const startingHour =
 				(beforeJumpingPoint.hour + (startingMinute === 0)) % 24;
 
-			// construct ranges to inspect. Using these, all possible seconds in the skipped range are checked.
-			const minuteRange = [];
-			const hourRange = [];
+			const hourRangeSize = afterJumpingPoint.hour - startingHour + 1;
+			const isHourJump = startingMinute === 0 && afterJumpingPoint.minute === 0;
 
-			// build the minute range. The jump is assumed to be at least 1 minute,
-			// so if the start and end minutes are equal, then there must be at least 1 hour of skipped time.
-			if (startingMinute === afterJumpingPoint.minute) {
-				minuteRange.push(...Array.from({ length: 60 }, (v, k) => k));
+			// There exist DST jumps other than 1 hour long, and the function is built to deal with it.
+			// It may be overkill to assume some cases, but it shouldn't cost much at runtime.
+			// https://en.wikipedia.org/wiki/Daylight_saving_time_by_country
+			if (hourRangeSize === 2 && isHourJump) {
+				// Exact 1 hour jump, most common real-world case.
+				// There is no need to check minutes and seconds, as any value would suffice.
+				return startingHour in this.hour;
+			} else if (hourRangeSize === 1) {
+				// less than 1 hour jump, rare but does exist.
+				return (
+					startingHour in this.hour &&
+					this._checkTimeInSkippedRangeSingleHour(
+						startingMinute,
+						afterJumpingPoint.minute
+					)
+				);
 			} else {
-				// we need a range inclusive to both numbers, possibly wrapping around the hour mark.
-				let minute = startingMinute;
-				minuteRange.push(minute);
-				while (minute !== afterJumpingPoint.minute) {
-					minute = (minute + 1) % 60;
-					minuteRange.push(minute); // ordered so that the afterJumpingPoint minute itself is also inserted.
-				}
+				// non-round or multi-hour jump. (does not exist in the real world at the time of writing)
+				return this._checkTimeInSkippedRangeMultiHour(
+					startingMinute,
+					afterJumpingPoint.minute,
+					startingHour,
+					afterJumpingPoint.hour
+				);
 			}
-
-			if (startingHour === afterJumpingPoint.hour) {
-				// assumed that the jump is less than 24 hours, so this must be the only hour.
-				hourRange.push(startingHour);
-			} else {
-				// we need a range inclusive to both numbers, possibly wrapping around the day mark.
-				// If a day wrap-around actually happens, other assumptions have been broken, but at least there won't be an infinite loop here.
-				let hour = startingHour;
-				hourRange.push(hour);
-				while (hour !== afterJumpingPoint.hour) {
-					hour = (hour + 1) % 24;
-					hourRange.push(hour);
-				}
-			}
-
-			console.log('minute range', minuteRange);
-			console.log('hour range', hourRange);
-
-			for (const h of hourRange) {
-				if (!(h in this.hour)) continue; // hour mismatch, not a valid time.
-
-				// edge case: Imagine a 30 minutes range from (x):45 to (x+1):15.
-				// With just a double for loop, we would explore (x):58, (x):59, !!(x):00!!, which is outside the skipped zone.
-				// Use a lower bound if we are in the first hour, as extra condition for the inner loop to avoid this.
-				let minuteLowerBound;
-				if (h === startingHour) {
-					minuteLowerBound = startingMinute;
-				} else {
-					minuteLowerBound = 0;
-				}
-
-				for (
-					let m = 0;
-					m < minuteRange.length && minuteRange[m] >= minuteLowerBound;
-					m++
-				) {
-					if (!(m in this.minute)) continue; // minute mismatch, not a valid time.
-
-					for (let s = 0; s < 60; s++) {
-						if (s in this.second) {
-							// full match, we have a valid time inside the range.
-							return true;
-						}
-					}
-				}
-			}
-
-			// there is nothing in the range.
-			return false;
 		},
 
+		/**
+		 * Component of checking if a CronJob time existed in a DateTime range skipped by DST.
+		 * This subroutine makes a further assumption that the skipped range is fully contained in one hour,
+		 * and that all other larger units are valid for the job.
+		 *
+		 * for example a jump from 02:00:00 to 02:30:00, but not from 02:00:00 to 03:00:00.
+		 * @see _checkTimeInSkippedRange
+		 *
+		 * This is done by checking if any minute in startMinute - endMinute is valid, excluding endMinute.
+		 * For endMinute, there is only a match if the 0th second is a valid time.
+		 */
+		_checkTimeInSkippedRangeSingleHour: function (startMinute, endMinute) {
+			for (let minute = startMinute; minute < endMinute; ++minute) {
+				if (minute in this.minute) return true;
+			}
+
+			// Unless the very last second of the jump matched, there is no match.
+			return endMinute in this.minute && 0 in this.second;
+		},
+
+		/**
+		 * Component of checking if a CronJob time existed in a DateTime range skipped by DST.
+		 * This subroutine assumes the jump touches at least 2 hours, but the jump does not necessarily fully contain these hours.
+		 */
+		_checkTimeInSkippedRangeMultiHour: function (
+			startMinute,
+			endMinute,
+			startHour,
+			endHour
+		) {
+			if (startHour >= endHour) {
+				throw new Error(
+					`ERROR: This DST checking related function assumes the forward jump starting hour (${startHour}) is less than the end hour (${endHour})`
+				);
+			}
+
+			/** @type number[] */
+			const firstHourMinuteRange = Array.from(
+				{ length: 60 - startMinute },
+				(_, k) => startMinute + k
+			);
+			/** @type {number[]} The final minute is not contained on purpose. Every minute in this range represents one for which any second is valid. */
+			const lastHourMinuteRange = Array.from(
+				{ length: endMinute },
+				(_, k) => k
+			);
+			/** @type number[] */
+			const middleHourMinuteRange = Array.from({ length: 60 }, (_, k) => k);
+
+			/** @type (number) => number[] */
+			const selectRange = forHour =>
+				forHour === startHour
+					? firstHourMinuteRange
+					: forHour === endHour
+					? lastHourMinuteRange
+					: middleHourMinuteRange;
+
+			// Include the endHour: Selecting the right range still ensures no values outside the skip are checked.
+			for (let hour = startHour; hour <= endHour; ++hour) {
+				if (!(hour in this.hour)) continue;
+
+				// The hour matches, so if the minute is in the range, we have a match!
+				const usingRange = selectRange(hour);
+
+				for (const minute of usingRange) {
+					// All minutes in any of the selected ranges represent minutes which are fully contained in the jump,
+					// So we need not check the seconds. If the minute is in there, it is a match.
+					if (minute in this.minute) return true;
+				}
+			}
+
+			// The endMinute of the endHour was not checked in the loop, because only the 0th second of it is in the range.
+			// Arriving here means no match was found yet, but this final check may turn up as a match.
+			return (
+				endHour in this.hour && endMinute in this.minute && 0 in this.second
+			);
+		},
 		/**
 		 * Given expected and actual hours and minutes, report if a DST forward jump occurred.
 		 *

--- a/lib/time.js
+++ b/lib/time.js
@@ -266,6 +266,7 @@ function CronTime(luxon) {
 			// determine next date
 			while (true) {
 				var diff = date - start;
+				console.log(date.toISO());
 
 				// hard stop if the current date is after the expected execution
 				if (Date.now() > timeout) {
@@ -514,6 +515,9 @@ function CronTime(luxon) {
 				}
 			}
 
+			console.log('minute range', minuteRange);
+			console.log('hour range', hourRange);
+
 			for (const h of hourRange) {
 				if (!(h in this.hour)) continue; // hour mismatch, not a valid time.
 
@@ -564,6 +568,8 @@ function CronTime(luxon) {
 
 			const hoursJumped = expectedHour % 24 < actualHour;
 			const minutesJumped = expectedMinute % 60 < actualMinute;
+
+			console.log('hours diff? ', expectedHour, actualHour, hoursJumped);
 
 			return hoursJumped || minutesJumped;
 		},

--- a/lib/time.js
+++ b/lib/time.js
@@ -424,6 +424,9 @@ function CronTime(luxon) {
 		 * When the jump is found, the range of the jump is investigated to check for acceptable cron times.
 		 * A pair is returned, whose first is a boolean representing if an acceptable time was found inside the jump,
 		 * and whose second is a DateTime representing the first millisecond after the jump.
+		 *
+		 * The input date is expected to be decently close to a DST jump.
+		 * Up to a day in the past is checked before an error is thrown.
 		 * @param date
 		 */
 		_findPreviousDSTJump: function (date) {
@@ -431,7 +434,17 @@ function CronTime(luxon) {
 			let expectedMinute, expectedHour, actualMinute, actualHour;
 			/** @type DateTime */
 			let maybeJumpingPoint;
+
+			// representing one day of backwards checking. If this is hit, the input must be wrong.
+			const iterationLimit = 60 * 24;
+			let iteration = 0;
 			do {
+				if (iteration++ > iterationLimit) {
+					throw new Error(
+						`ERROR: This DST checking related function assumes the input DateTime (${date.toISO()}) is within 24 hours of a DST jump.`
+					);
+				}
+
 				expectedMinute = date.minute - 1;
 				expectedHour = date.hour - 1;
 

--- a/lib/time.js
+++ b/lib/time.js
@@ -598,12 +598,15 @@ function CronTime(luxon) {
 			const middleHourMinuteRange = Array.from({ length: 60 }, (_, k) => k);
 
 			/** @type (number) => number[] */
-			const selectRange = forHour =>
-				forHour === startHour
-					? firstHourMinuteRange
-					: forHour === endHour
-					? lastHourMinuteRange
-					: middleHourMinuteRange;
+			const selectRange = forHour => {
+				if (forHour === startHour) {
+					return firstHourMinuteRange;
+				} else if (forHour === endHour) {
+					return lastHourMinuteRange;
+				} else {
+					return middleHourMinuteRange;
+				}
+			};
 
 			// Include the endHour: Selecting the right range still ensures no values outside the skip are checked.
 			for (let hour = startHour; hour <= endHour; ++hour) {

--- a/lib/time.js
+++ b/lib/time.js
@@ -532,10 +532,10 @@ function CronTime(luxon) {
 			} else {
 				// non-round or multi-hour jump. (does not exist in the real world at the time of writing)
 				return this._checkTimeInSkippedRangeMultiHour(
-					startingMinute,
-					afterJumpingPoint.minute,
 					startingHour,
-					afterJumpingPoint.hour
+					startingMinute,
+					afterJumpingPoint.hour,
+					afterJumpingPoint.minute
 				);
 			}
 		},
@@ -571,12 +571,17 @@ function CronTime(luxon) {
 		 *
 		 * If any hour x minute combination is a valid time, true is returned.
 		 * The endMinute x endHour combination is only checked with the 0th second, since the rest would be out of the range.
+		 *
+		 * @param startHour {number}
+		 * @param startMinute {number}
+		 * @param endHour {number}
+		 * @param endMinute {number}
 		 */
 		_checkTimeInSkippedRangeMultiHour: function (
-			startMinute,
-			endMinute,
 			startHour,
-			endHour
+			startMinute,
+			endHour,
+			endMinute
 		) {
 			if (startHour >= endHour) {
 				throw new Error(

--- a/lib/time.js
+++ b/lib/time.js
@@ -266,6 +266,7 @@ function CronTime(luxon) {
 			// determine next date
 			while (true) {
 				var diff = date - start;
+				console.log(date.toISO());
 
 				// hard stop if the current date is after the expected execution
 				if (Date.now() > timeout) {
@@ -283,6 +284,12 @@ function CronTime(luxon) {
 				) {
 					date = date.plus({ months: 1 });
 					date = date.set({ day: 1, hour: 0, minute: 0, second: 0 });
+
+					if (this._forwardDSTJump(0, 0, date)) {
+						const [done, newDate] = this._findPreviousDSTJump(date);
+						date = newDate;
+						if (done) break;
+					}
 					continue;
 				}
 
@@ -296,6 +303,12 @@ function CronTime(luxon) {
 				) {
 					date = date.plus({ days: 1 });
 					date = date.set({ hour: 0, minute: 0, second: 0 });
+
+					if (this._forwardDSTJump(0, 0, date)) {
+						const [done, newDate] = this._findPreviousDSTJump(date);
+						date = newDate;
+						if (done) break;
+					}
 					continue;
 				}
 
@@ -309,14 +322,34 @@ function CronTime(luxon) {
 				) {
 					date = date.plus({ days: 1 });
 					date = date.set({ hour: 0, minute: 0, second: 0 });
+					if (this._forwardDSTJump(0, 0, date)) {
+						const [done, newDate] = this._findPreviousDSTJump(date);
+						date = newDate;
+						if (done) break;
+					}
 					continue;
 				}
 
 				if (!(date.hour in this.hour) && Object.keys(this.hour).length !== 24) {
-					date = date.set({
-						hour: date.hour === 23 && diff > 86400000 ? 0 : date.hour + 1
-					});
+					const expectedHour =
+						date.hour === 23 && diff > 86400000 ? 0 : date.hour + 1;
+					const expectedMinute = date.minute; // expect no change.
+
+					date = date.set({ hour: expectedHour });
 					date = date.set({ minute: 0, second: 0 });
+
+					// When this is the case, Asking luxon to go forward by 1 hour actually made us go forward by more hours...
+					// This indicates that somewhere between these two time points, a forward DST adjustment has happened.
+					// When this happens, the job should be scheduled to execute as though the time has come when the jump is made.
+					// Therefore, the job should be scheduled on the first tick after the forward jump.
+					if (this._forwardDSTJump(expectedHour, expectedMinute, date)) {
+						const [done, newDate] = this._findPreviousDSTJump(date);
+						date = newDate;
+						if (done) break;
+					}
+					// backwards jumps do not seem to have any problems (i.e. double activations),
+					// so they need not be handled in a similar way.
+
 					continue;
 				}
 
@@ -324,10 +357,21 @@ function CronTime(luxon) {
 					!(date.minute in this.minute) &&
 					Object.keys(this.minute).length !== 60
 				) {
-					date = date.set({
-						minute: date.minute === 59 && diff > 3600000 ? 0 : date.minute + 1
-					});
+					const expectedMinute =
+						date.minute === 59 && diff > 3600000 ? 0 : date.minute + 1;
+					const expectedHour = date.hour + (expectedMinute === 60);
+
+					date = date.set({ minute: expectedMinute });
 					date = date.set({ second: 0 });
+
+					// Same case as with hours: DST forward jump.
+					// This must be accounted for if a minute increment pushed us to a jumping point.
+					if (this._forwardDSTJump(expectedHour, expectedMinute, date)) {
+						const [done, newDate] = this._findPreviousDSTJump(date);
+						date = newDate;
+						if (done) break;
+					}
+
 					continue;
 				}
 
@@ -335,14 +379,37 @@ function CronTime(luxon) {
 					!(date.second in this.second) &&
 					Object.keys(this.second).length !== 60
 				) {
-					date = date.set({
-						second: date.second === 59 && diff > 60000 ? 0 : date.second + 1
-					});
+					const expectedSecond =
+						date.second === 59 && diff > 60000 ? 0 : date.second + 1;
+					const expectedMinute = date.minute + (expectedSecond === 60);
+					const expectedHour = date.hour + (expectedMinute === 60);
+
+					date = date.set({ second: expectedSecond });
+
+					// Seconds can cause it too, imagine 21:59:59 -> 23:00:00.
+					if (this._forwardDSTJump(expectedHour, expectedMinute, date)) {
+						const [done, newDate] = this._findPreviousDSTJump(date);
+						date = newDate;
+						if (done) break;
+					}
+
 					continue;
 				}
 
 				if (date.toMillis() === firstDate) {
-					date = date.set({ second: date.second + 1 });
+					const expectedSecond = date.second + 1;
+					const expectedMinute = date.minute + (expectedSecond === 60);
+					const expectedHour = date.hour + (expectedMinute === 60);
+
+					date = date.set({ second: expectedSecond });
+
+					// Same as always.
+					if (this._forwardDSTJump(expectedHour, expectedMinute, date)) {
+						const [done, newDate] = this._findPreviousDSTJump(date);
+						date = newDate;
+						if (done) break;
+					}
+
 					continue;
 				}
 
@@ -350,6 +417,161 @@ function CronTime(luxon) {
 			}
 
 			return date;
+		},
+
+		/**
+		 * Search backwards in time 1 minute at a time, to detect a DST forward jump.
+		 * When the jump is found, the range of the jump is investigated to check for acceptable cron times.
+		 * A pair is returned, whose first is a boolean representing if an acceptable time was found inside the jump,
+		 * and whose second is a DateTime representing the first millisecond after the jump.
+		 * @param date
+		 */
+		_findPreviousDSTJump: function (date) {
+			/** @type number */
+			let expectedMinute, expectedHour, actualMinute, actualHour;
+			/** @type DateTime */
+			let maybeJumpingPoint;
+			do {
+				expectedMinute = date.minute - 1;
+				expectedHour = date.hour - 1;
+
+				if (expectedMinute < 0) expectedMinute += 60;
+				if (expectedHour < 0) expectedHour += 60;
+
+				maybeJumpingPoint = date.minus({ minute: 1 });
+
+				actualMinute = maybeJumpingPoint.minute;
+				actualHour = maybeJumpingPoint.hour;
+			} while (expectedMinute === actualMinute && expectedHour === actualHour);
+
+			const afterJumpingPoint = maybeJumpingPoint
+				.plus({ minute: 1 }) // back to the first minute _after_ the jump
+				.set({ seconds: 0, millisecond: 0 }); // and set seconds and MS to zero.
+			const beforeJumpingPoint = afterJumpingPoint.minus({ second: 1 });
+
+			if (
+				date.month in this.month &&
+				date.day in this.dayOfMonth &&
+				date.getWeekDay() in this.dayOfWeek
+			) {
+				return [
+					this._checkTimeInSkippedRange(beforeJumpingPoint, afterJumpingPoint),
+					afterJumpingPoint
+				];
+			}
+
+			// no valid time in the range for sure, units that didn't change from the skip mismatch.
+			return [false, afterJumpingPoint];
+		},
+
+		/**
+		 * Given 2 DateTimes, which represent 1 second before and immediately after a DST forward jump,
+		 * checks if a time in the skipped range would have been a valid CronJob time.
+		 *
+		 * Assumes the DST jump started no earlier than 0:00 and jumped forward by at least 1 minute, to at most 23:59.
+		 * i.e. The day is assumed constant, but the jump is not assumed to be an hour long.
+		 * Empirically, it is almost always one hour, but very, very rarely 30 minutes.
+		 *
+		 * Assumes dayOfWeek, dayOfMonth and month match all match, so only the hours, minutes and seconds are to be checked.
+		 * @param {DateTime} beforeJumpingPoint
+		 * @param {DateTime} afterJumpingPoint
+		 * @returns {boolean}
+		 */
+		_checkTimeInSkippedRange: function (beforeJumpingPoint, afterJumpingPoint) {
+			// start by getting the first minute inside the skipped range.
+			const startingMinute = (beforeJumpingPoint.minute + 1) % 60;
+			const startingHour =
+				(beforeJumpingPoint.hour + (startingMinute === 0)) % 24;
+
+			// construct ranges to inspect. Using these, all possible seconds in the skipped range are checked.
+			const minuteRange = [];
+			const hourRange = [];
+
+			// build the minute range. The jump is assumed to be at least 1 minute,
+			// so if the start and end minutes are equal, then there must be at least 1 hour of skipped time.
+			if (startingMinute === afterJumpingPoint.minute) {
+				minuteRange.push(...Array.from({ length: 60 }, (v, k) => k));
+			} else {
+				// we need a range inclusive to both numbers, possibly wrapping around the hour mark.
+				let minute = startingMinute;
+				minuteRange.push(minute);
+				while (minute !== afterJumpingPoint.minute) {
+					minute = (minute + 1) % 60;
+					minuteRange.push(minute); // ordered so that the afterJumpingPoint minute itself is also inserted.
+				}
+			}
+
+			if (startingHour === afterJumpingPoint.hour) {
+				// assumed that the jump is less than 24 hours, so this must be the only hour.
+				hourRange.push(startingHour);
+			} else {
+				// we need a range inclusive to both numbers, possibly wrapping around the day mark.
+				// If a day wrap-around actually happens, other assumptions have been broken, but at least there won't be an infinite loop here.
+				let hour = startingHour;
+				hourRange.push(hour);
+				while (hour !== afterJumpingPoint.hour) {
+					hour = (hour + 1) % 24;
+					hourRange.push(hour);
+				}
+			}
+
+			console.log('minute range', minuteRange);
+			console.log('hour range', hourRange);
+
+			for (const h of hourRange) {
+				if (!(h in this.hour)) continue; // hour mismatch, not a valid time.
+
+				// edge case: Imagine a 30 minutes range from (x):45 to (x+1):15.
+				// With just a double for loop, we would explore (x):58, (x):59, !!(x):00!!, which is outside the skipped zone.
+				// Use a lower bound if we are in the first hour, as extra condition for the inner loop to avoid this.
+				let minuteLowerBound;
+				if (h === startingHour) {
+					minuteLowerBound = startingMinute;
+				} else {
+					minuteLowerBound = 0;
+				}
+
+				for (
+					let m = 0;
+					m < minuteRange.length && minuteRange[m] >= minuteLowerBound;
+					m++
+				) {
+					if (!(m in this.minute)) continue; // minute mismatch, not a valid time.
+
+					for (let s = 0; s < 60; s++) {
+						if (s in this.second) {
+							// full match, we have a valid time inside the range.
+							return true;
+						}
+					}
+				}
+			}
+
+			// there is nothing in the range.
+			return false;
+		},
+
+		/**
+		 * Given expected and actual hours and minutes, report if a DST forward jump occurred.
+		 *
+		 * This is the case when the expected is smaller than the acutal.
+		 *
+		 * It is not sufficient to check only hours, because some parts of the world apply DST by shifting in minutes.
+		 * Better to account for it by checking minutes too, before an Australian of Lord Howe Island call us.
+		 * @param expectedHour
+		 * @param expectedMinute
+		 * @param {DateTime} actualDate
+		 */
+		_forwardDSTJump: function (expectedHour, expectedMinute, actualDate) {
+			const actualHour = actualDate.hour;
+			const actualMinute = actualDate.minute;
+
+			const hoursJumped = expectedHour % 24 < actualHour;
+			const minutesJumped = expectedMinute % 60 < actualMinute;
+
+			console.log('hours diff? ', expectedHour, actualHour, hoursJumped);
+
+			return hoursJumped || minutesJumped;
 		},
 
 		/**

--- a/lib/time.js
+++ b/lib/time.js
@@ -422,12 +422,14 @@ function CronTime(luxon) {
 		/**
 		 * Search backwards in time 1 minute at a time, to detect a DST forward jump.
 		 * When the jump is found, the range of the jump is investigated to check for acceptable cron times.
+		 *
 		 * A pair is returned, whose first is a boolean representing if an acceptable time was found inside the jump,
 		 * and whose second is a DateTime representing the first millisecond after the jump.
 		 *
 		 * The input date is expected to be decently close to a DST jump.
 		 * Up to a day in the past is checked before an error is thrown.
 		 * @param date
+		 * @return [boolean, DateTime]
 		 */
 		_findPreviousDSTJump: function (date) {
 			/** @type number */
@@ -459,9 +461,14 @@ function CronTime(luxon) {
 				actualHour = maybeJumpingPoint.hour;
 			} while (expectedMinute === actualMinute && expectedHour === actualHour);
 
+			// Setting the seconds and milliseconds to zero is necessary for two reasons:
+			// Firstly, the range checking function needs the earliest moment after the jump.
+			// Secondly, this DateTime may be used for scheduling jobs, if there existed a job in the skipped range.
 			const afterJumpingPoint = maybeJumpingPoint
 				.plus({ minute: 1 }) // back to the first minute _after_ the jump
-				.set({ seconds: 0, millisecond: 0 }); // and set seconds and MS to zero.
+				.set({ seconds: 0, millisecond: 0 });
+
+			// Get the lower bound of the range to check as well. This only has to be accurate down to minutes.
 			const beforeJumpingPoint = afterJumpingPoint.minus({ second: 1 });
 
 			if (
@@ -482,6 +489,11 @@ function CronTime(luxon) {
 		/**
 		 * Given 2 DateTimes, which represent 1 second before and immediately after a DST forward jump,
 		 * checks if a time in the skipped range would have been a valid CronJob time.
+		 *
+		 * Could technically work with just one of these values, extracting the other by adding or subtracting seconds.
+		 * However, this couples the input DateTime to actually being tied to a DST jump,
+		 * which would make the function harder to test.
+		 * This way the logic just tests a range of minutes and hours, regardless if there are skipped time points underneath.
 		 *
 		 * Assumes the DST jump started no earlier than 0:00 and jumped forward by at least 1 minute, to at most 23:59.
 		 * i.e. The day is assumed constant, but the jump is not assumed to be an hour long.

--- a/tests/crontime.test.js
+++ b/tests/crontime.test.js
@@ -514,7 +514,7 @@ describe('crontime', () => {
 	it('Enforces the hour difference assumption for handling multi-hour DST jumps', () => {
 		const cronTime = new cron.CronTime('30 16 * * *');
 		expect(() => {
-			cronTime._checkTimeInSkippedRangeMultiHour(0, 30, 15, 15);
+			cronTime._checkTimeInSkippedRangeMultiHour(15, 0, 15, 30);
 		}).toThrow();
 	});
 	it('should generate the right N next days for * * * * *', () => {

--- a/tests/crontime.test.js
+++ b/tests/crontime.test.js
@@ -439,6 +439,20 @@ describe('crontime', () => {
 		jobInRange = cronTime._checkTimeInSkippedRange(startDate, endDate);
 		expect(jobInRange).toEqual(true);
 	});
+	it('Should not include seconds in the minute after the DST jump as part of the jump scan', () => {
+		const endDate = luxon.DateTime.fromISO('2023-01-01T16:00:00.000', {
+			zone: 'Europe/Amsterdam'
+		});
+		// 1 hour jump case
+		let startDate = endDate.minus({ hour: 1, second: 1 });
+		const cronTime = new cron.CronTime('1 5 16 * * *'); // at 16:00:01.
+		let jobInRange = cronTime._checkTimeInSkippedRange(startDate, endDate);
+		expect(jobInRange).toEqual(false);
+		// 'quirky' jump case
+		startDate = endDate.minus({ hour: 1, minute: 45, second: 1 });
+		jobInRange = cronTime._checkTimeInSkippedRange(startDate, endDate);
+		expect(jobInRange).toEqual(false);
+	});
 	it('Should correctly scan time periods as if they are DST jumps, full hour jumps', () => {
 		let endDate = luxon.DateTime.fromISO('2023-01-01T16:00:00.000', {
 			zone: 'Europe/Amsterdam'


### PR DESCRIPTION
This fixes issue #638 

it does this by 

1) detecting a forward jump in time happened after changing the time of a date in _getNextDate()
2) Scanning the jumped-over range for matches with the time pattern.

What made (2) extra tricky is that apparently, DST is not uniformly 1 hour. That made things a little more complicated.
Right now the skipped range scanner assumes a forward jump is 1 minute to 23 hrs 59 minutes long, and does not roll over days.

This PR also fixes a test that was failing on the master branch, by disambiguating a DateTime (the ISO string represented 2 possible times due to a DST backwards shift, and luxon picked the unfavorable one).

**An important** thing to know about this change, is that it also fixes another, more minor bug with _getNextDate(), namely that a jumped-over time candidate is not considered. E.g. an `every *:30:00'`job does not activate at 2:30 if the time jumps from 1 to 3. (I would expect it to, and it now does, activate at 1:30, 3:00 and 3:30 respectively). Because the time of 3:00 represents every time of day between 2 and 3 all at once.

For example, how the [original Cron handles DST:](https://www.unix.com/man-page/Linux/8/cron/)

```
 Special considerations exist when the clock is changed by less than 3 hours, for example at the beginning and end of daylight savings time.
       If the time has moved forwards, those jobs which would have run in the time that was skipped will be  run  soon	after  the  change.   Con-
       versely, if the time has moved backwards by less than 3 hours, those jobs that fall into the repeated time will not be re-run.

       Only  jobs  that run at a particular time (not specified as @hourly, nor with '*' in the hour or minute specifier) are affected. Jobs which
       are specified with wildcards are run based on the new time immediately.
```

Backwards jumps were handled just like this, but forward ones not as much.

This is however a change you probably want to be aware of as maintainers of this library, Maybe you know of use cases for node-cron where actually the opposite, current behavior is preferred?