### PR TITLE
Changed .format > .toFormat #643

### DIFF
--- a/lib/time.js
+++ b/lib/time.js
@@ -268,7 +268,7 @@ function CronTime(luxon) {
 					throw new Error(
 						`Something went wrong. It took over five seconds to find the next execution time for the cron job.
 							Please refer to the canonical issue (https://github.com/kelektiv/node-cron/issues/467) and provide the following string if you would like to help debug:
-							Time Zone: ${zone || '""'} - Cron String: ${this} - UTC offset: ${date.format(
+							Time Zone: ${zone || '""'} - Cron String: ${this} - UTC offset: ${date.toFormat(
 							'Z'
 						)} - current Date: ${luxon.DateTime.local().toString()}`
 					);


### PR DESCRIPTION
Luxon seems to have changed their function name:

In the current code, if you end up in this error clause, the message will not log due to the wrong function being called. 
(Error also reported in: https://github.com/kelektiv/node-cron/issues/643)

<img width="918" alt="image" src="https://user-images.githubusercontent.com/3114694/213404894-b019b8da-d0c4-47d9-aa98-dd8902802cb7.png">
Relevant code line: https://github.com/kelektiv/node-cron/blob/master/lib/time.js#L271


By Updating to the new function name, the error is thrown as intended:
<img width="925" alt="image" src="https://user-images.githubusercontent.com/3114694/213405039-38021407-8420-4eef-9b1c-52a4d171d9f5.png">


Image of error being logged properly with the new change
<img width="1205" alt="image" src="https://user-images.githubusercontent.com/3114694/213405300-ca4bdd4d-48b7-4723-a1cb-60daf5010297.png">



https://moment.github.io/luxon/#/formatting?id=toformat