### PR TITLE
fix: don't start job in setTime if it wasn't running

### DIFF
--- a/lib/job.js
+++ b/lib/job.js
@@ -88,9 +88,10 @@ function CronJob(CronTime, spawn) {
 			// crontime is an object...
 			throw new Error('time must be an instance of CronTime.');
 		}
+		const wasRunning = this.running;
 		this.stop();
 		this.cronTime = time;
-		this.start();
+		if (wasRunning) this.start();
 	};
 
 	CJ.prototype.nextDate = function () {

--- a/tests/cron.test.js
+++ b/tests/cron.test.js
@@ -854,10 +854,8 @@ describe('cron', () => {
 			job.start();
 			clock.tick(1000);
 
-			job.stop();
 			const time = cron.time('*/2 * * * * *');
 			job.setTime(time);
-			job.start();
 
 			clock.tick(4000);
 
@@ -885,7 +883,6 @@ describe('cron', () => {
 
 			clock.tick(1000);
 
-			job.stop();
 			expect(() => {
 				job.setTime(time);
 			}).toThrow();

--- a/tests/cron.test.js
+++ b/tests/cron.test.js
@@ -452,56 +452,6 @@ describe('cron', () => {
 		});
 	});
 
-	it('should start, change time, start again', () => {
-		const callback = jest.fn();
-		const clock = sinon.useFakeTimers();
-
-		const job = new cron.CronJob('* * * * * *', callback);
-
-		job.start();
-		clock.tick(1000);
-
-		job.stop();
-		const time = cron.time('*/2 * * * * *');
-		job.setTime(time);
-		job.start();
-
-		clock.tick(4000);
-
-		clock.restore();
-		job.stop();
-		expect(callback).toHaveBeenCalledTimes(3);
-	});
-
-	it('should setTime with invalid object', () => {
-		const callback = jest.fn();
-		const job = new cron.CronJob('* * * * * *', callback);
-		expect(() => {
-			job.setTime(undefined);
-		}).toThrow();
-	});
-
-	it('should start, change time, exception', () => {
-		const callback = jest.fn();
-		const clock = sinon.useFakeTimers();
-
-		const job = new cron.CronJob('* * * * * *', callback);
-
-		const time = new Date();
-		job.start();
-
-		clock.tick(1000);
-
-		job.stop();
-		expect(() => {
-			job.setTime(time);
-		}).toThrow();
-
-		clock.restore();
-		job.stop();
-		expect(callback).toHaveBeenCalledTimes(1);
-	});
-
 	it('should scope onTick to running job', () => {
 		const clock = sinon.useFakeTimers();
 
@@ -891,6 +841,58 @@ describe('cron', () => {
 			expect(() => {
 				new cron.CronTime('* * 32 FEB *');
 			}).toThrow();
+		});
+	});
+
+	describe('setTime', () => {
+		it('should start, change time, start again', () => {
+			const callback = jest.fn();
+			const clock = sinon.useFakeTimers();
+
+			const job = new cron.CronJob('* * * * * *', callback);
+
+			job.start();
+			clock.tick(1000);
+
+			job.stop();
+			const time = cron.time('*/2 * * * * *');
+			job.setTime(time);
+			job.start();
+
+			clock.tick(4000);
+
+			clock.restore();
+			job.stop();
+			expect(callback).toHaveBeenCalledTimes(3);
+		});
+
+		it('should setTime with invalid object', () => {
+			const callback = jest.fn();
+			const job = new cron.CronJob('* * * * * *', callback);
+			expect(() => {
+				job.setTime(undefined);
+			}).toThrow();
+		});
+
+		it('should start, change time, exception', () => {
+			const callback = jest.fn();
+			const clock = sinon.useFakeTimers();
+
+			const job = new cron.CronJob('* * * * * *', callback);
+
+			const time = new Date();
+			job.start();
+
+			clock.tick(1000);
+
+			job.stop();
+			expect(() => {
+				job.setTime(time);
+			}).toThrow();
+
+			clock.restore();
+			job.stop();
+			expect(callback).toHaveBeenCalledTimes(1);
 		});
 	});
 

--- a/tests/cron.test.js
+++ b/tests/cron.test.js
@@ -864,6 +864,26 @@ describe('cron', () => {
 			expect(callback).toHaveBeenCalledTimes(3);
 		});
 
+		it('should start, stop, change time, not start again', () => {
+			const callback = jest.fn();
+			const clock = sinon.useFakeTimers();
+
+			const job = new cron.CronJob('* * * * * *', callback);
+
+			job.start();
+			clock.tick(1000);
+
+			job.stop();
+			const time = cron.time('*/2 * * * * *');
+			job.setTime(time);
+
+			clock.tick(4000);
+
+			clock.restore();
+			job.stop();
+			expect(callback).toHaveBeenCalledTimes(1);
+		});
+
 		it('should setTime with invalid object', () => {
 			const callback = jest.fn();
 			const job = new cron.CronJob('* * * * * *', callback);


### PR DESCRIPTION
I started by wrapping the `setTime` test cases in a `describe`, so changes might not be obvious for `tests/cron.test.js`. Please see the commits detail for better readability.

Fixes #598.