### PR TITLE
ci: add support for beta & maintenance releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,8 @@ on:
   push:
     branches:
       - main
+      - beta
+      - '+([0-9])?(.{+([0-9]),x}).x'
 
 jobs:
   lint-and-test:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,6 +5,8 @@ on:
   pull_request:
     branches:
       - master
+      - beta
+      - '+([0-9])?(.{+([0-9]),x}).x'
 
 jobs:
   lint-and-test:

--- a/.releaserc
+++ b/.releaserc
@@ -1,7 +1,12 @@
 {
 	"repositoryUrl": "git@github.com:kelektiv/node-cron.git",
 	"branches": [
-		"master"
+		"master",
+		{
+			"name": "beta",
+			"prerelease": true
+		},
+		"+([0-9])?(.{+([0-9]),x}).x"
 	],
 	"tagFormat": "v${version}",
 	"plugins": [


### PR DESCRIPTION
## Description
This PR updates GitHub Actions & Semantic Release configuration files in order to support beta & maintenance releases.

## Relevant documentation
- https://github.com/semantic-release/semantic-release/blob/master/docs/usage/configuration.md#branches
- https://github.com/semantic-release/semantic-release/blob/master/docs/recipes/release-workflow/pre-releases.md
- https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#onpull_requestpull_request_targetbranchesbranches-ignore