### PR TITLE
ci: fix duplicate GitHub actions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,7 +5,6 @@ on:
     branches:
       - main
       - beta
-      - '+([0-9])?(.{+([0-9]),x}).x'
 
 jobs:
   lint-and-test:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,7 +6,6 @@ on:
     branches:
       - main
       - beta
-      - '+([0-9])?(.{+([0-9]),x}).x'
 
 jobs:
   lint-and-test:


### PR DESCRIPTION
## Description
GitHub seems to be unable to parse the maintenance releases branches regex correctly, and it triggers both Test / Release workflows for any branches (at least for `main` & `beta`), which leads to duplicate actions running at the same time.

So I removed the regex from the workflows to fix this issue. That implies we'll have to add maintenance branches manually to the workflows when creating them.