### PR TITLE
fix: replace loop timeout by max match date

### DIFF
--- a/lib/time.js
+++ b/lib/time.js
@@ -259,19 +259,23 @@ function CronTime(luxon) {
 				throw new Error('ERROR: You specified an invalid date.');
 			}
 
-			// it shouldn't take more than 5 seconds to find the next execution time
-			// being very generous with this. Throw error if it takes too long to find the next time to protect from
-			// infinite loop.
-			const timeout = Date.now() + 5000;
+			/**
+			 * maximum match interval is 8 years:
+			 * crontab has '* * 29 2 *' and we are on 1 March 2096:
+			 * next matching time will be 29 February 2104
+			 * source: https://github.com/cronie-crond/cronie/blob/0d669551680f733a4bdd6bab082a0b3d6d7f089c/src/cronnext.c#L401-L403
+			 */
+			const maxMatch = luxon.DateTime.now().plus({ years: 8 });
+
 			// determine next date
 			while (true) {
 				const diff = date - start;
 
-				// hard stop if the current date is after the expected execution
-				if (Date.now() > timeout) {
+				// hard stop if the current date is after the maximum match interval
+				if (date > maxMatch) {
 					throw new Error(
-						`Something went wrong. It took over five seconds to find the next execution time for the cron job.
-							Please refer to the canonical issue (https://github.com/kelektiv/node-cron/issues/467) and provide the following string if you would like to help debug:
+						`Something went wrong. No execution date was found in the next 8 years.
+							Please provide the following string if you would like to help debug:
 							Time Zone: ${zone || '""'} - Cron String: ${this} - UTC offset: ${date.offset}
 							- current Date: ${luxon.DateTime.local().toString()}`
 					);


### PR DESCRIPTION
## Description
This change is inspired by [cronie's `crond`](https://github.com/cronie-crond/cronie/blob/master/src/cronnext.c).
It replaces the 5 seconds timeout in the `_getNextDateFrom` while loop by a maximum date in the future (8 years).

## Related Issue
Fixes #467.
Closes #499.

## Motivation and Context
In environments with limited resources (CPU/memory), it may take more than 5 seconds to find the next date. This throws an error (see #467), while it should only take the time it needs and find the occurence.

## How Has This Been Tested?
Using [the `systemd-run` command](https://github.com/kelektiv/node-cron/issues/467#issuecomment-1580693046), I've been able to compare the behavior of test runs between the `main` branch and this version and to confirm that these changes have all tests passing correctly in a low resources environment.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [X] All new and existing tests passed.
- [ ] If my change introduces a breaking change, I have added a `!` after the type/scope in the title (see the Conventional Commits standard).

*This issue was initially [discussed on Discord](https://discord.com/channels/1075597081017851934/1140229792533327922).*