### PR TITLE
fix: fix range parsing when upper limit = 0

### DIFF
--- a/lib/time.js
+++ b/lib/time.js
@@ -768,7 +768,7 @@ function CronTime(luxon) {
 				if (allRanges[i].match(RE_RANGE)) {
 					allRanges[i].replace(RE_RANGE, ($0, lower, upper, step) => {
 						lower = parseInt(lower, 10);
-						upper = parseInt(upper, 10) || undefined;
+						upper = upper !== undefined ? parseInt(upper, 10) : undefined;
 
 						const wasStepDefined = !isNaN(parseInt(step, 10));
 						if (step === '0') {
@@ -776,14 +776,14 @@ function CronTime(luxon) {
 						}
 						step = parseInt(step, 10) || 1;
 
-						if (upper && lower > upper) {
+						if (upper !== undefined && lower > upper) {
 							throw new Error(`Field (${type}) has an invalid range`);
 						}
 
 						const outOfRangeError =
 							lower < low ||
-							(upper && upper > high) ||
-							(!upper && lower > high);
+							(upper !== undefined && upper > high) ||
+							(upper === undefined && lower > high);
 
 						if (outOfRangeError) {
 							throw new Error(`Field value (${value}) is out of range`);
@@ -793,7 +793,7 @@ function CronTime(luxon) {
 						lower = Math.min(Math.max(low, ~~Math.abs(lower)), high);
 
 						// Positive integer lower than constraints[1]
-						if (upper) {
+						if (upper !== undefined) {
 							upper = Math.min(high, ~~Math.abs(upper));
 						} else {
 							// If step is provided, the default upper range is the highest value

--- a/tests/crontime.test.js
+++ b/tests/crontime.test.js
@@ -70,6 +70,12 @@ describe('crontime', () => {
 		}).not.toThrow();
 	});
 
+	it('should accept all valid ranges (0-59 0-59 1-23 1-31 0-12 0-6)', () => {
+		expect(() => {
+			new cron.CronTime('0-59 0-59 1-23 1-31 0-11 0-6');
+		}).not.toThrow();
+	});
+
 	it('should test comma (0,10 * * * * *)', () => {
 		expect(() => {
 			new cron.CronTime('0,10 * * * * *');

--- a/tests/crontime.test.js
+++ b/tests/crontime.test.js
@@ -152,6 +152,14 @@ describe('crontime', () => {
 		expect(() => {
 			new cron.CronTime('* 2-1 * * *');
 		}).toThrow();
+
+		expect(() => {
+			new cron.CronTime('* 2-0 * * *');
+		}).toThrow();
+
+		expect(() => {
+			new cron.CronTime('* 2- * * *');
+		}).toThrow();
 	});
 
 	it('should test Date', () => {


### PR DESCRIPTION
## Description
When providing the invalid value `0` as the upper limit in a range (e.g. `2-0`), the library was not detecting the error due to the use of the `||` operator, which considers `0` & `undefined` the same way.
I have replaced the operator to check specifically for `undefined` in order to detect the invalid value `0`.

## Related Issue
Fixes #654.

## How Has This Been Tested?
I have extended an existing test case to check for invalid ranges and added a test case that checks all valid ranges are accepted.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
- [ ] If my change introduces a breaking change, I have added a `!` after the type/scope in the title (see the Conventional Commits standard).
