### PR TITLE
fix(deps): update dependency luxon to v3.3.0 & add @types/luxon

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,8 @@
 			"version": "2.4.1",
 			"license": "MIT",
 			"dependencies": {
-				"luxon": "^3.2.1"
+				"@types/luxon": "~3.3.0",
+				"luxon": "~3.3.0"
 			},
 			"devDependencies": {
 				"@commitlint/cli": "~17.6.6",
@@ -2267,6 +2268,11 @@
 			"version": "0.0.29",
 			"dev": true,
 			"license": "MIT"
+		},
+		"node_modules/@types/luxon": {
+			"version": "3.3.1",
+			"resolved": "https://registry.npmjs.org/@types/luxon/-/luxon-3.3.1.tgz",
+			"integrity": "sha512-XOS5nBcgEeP2PpcqJHjCWhUCAzGfXIU8ILOSLpx2FhxqMW9KdxgCGXNOEKGVBfveKtIpztHzKK5vSRVLyW/NqA=="
 		},
 		"node_modules/@types/minimist": {
 			"version": "1.2.2",
@@ -6423,8 +6429,9 @@
 			}
 		},
 		"node_modules/luxon": {
-			"version": "3.2.1",
-			"license": "MIT",
+			"version": "3.3.0",
+			"resolved": "https://registry.npmjs.org/luxon/-/luxon-3.3.0.tgz",
+			"integrity": "sha512-An0UCfG/rSiqtAIiBPO0Y9/zAnHUZxAMiCpTd5h2smgsj7GGmcenvrvww2cqNA8/4A5ZrD1gJpHN2mIHZQF+Mg==",
 			"engines": {
 				"node": ">=12"
 			}
@@ -14475,6 +14482,11 @@
 			"version": "0.0.29",
 			"dev": true
 		},
+		"@types/luxon": {
+			"version": "3.3.1",
+			"resolved": "https://registry.npmjs.org/@types/luxon/-/luxon-3.3.1.tgz",
+			"integrity": "sha512-XOS5nBcgEeP2PpcqJHjCWhUCAzGfXIU8ILOSLpx2FhxqMW9KdxgCGXNOEKGVBfveKtIpztHzKK5vSRVLyW/NqA=="
+		},
 		"@types/minimist": {
 			"version": "1.2.2",
 			"resolved": "https://registry.npmjs.org/@types/minimist/-/minimist-1.2.2.tgz",
@@ -17351,7 +17363,9 @@
 			}
 		},
 		"luxon": {
-			"version": "3.2.1"
+			"version": "3.3.0",
+			"resolved": "https://registry.npmjs.org/luxon/-/luxon-3.3.0.tgz",
+			"integrity": "sha512-An0UCfG/rSiqtAIiBPO0Y9/zAnHUZxAMiCpTd5h2smgsj7GGmcenvrvww2cqNA8/4A5ZrD1gJpHN2mIHZQF+Mg=="
 		},
 		"make-dir": {
 			"version": "3.1.0",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
 	},
 	"types": "types/index.d.ts",
 	"dependencies": {
-		"luxon": "^3.2.1"
+		"@types/luxon": "~3.3.0",
+		"luxon": "~3.3.0"
 	},
 	"devDependencies": {
 		"@commitlint/cli": "~17.6.6",


### PR DESCRIPTION
## Description
- added `@types/luxon` to dependencies
- updated Luxon from `v3.2.1` to `v3.3.0` (avoided `v3.4.0` since types aren't available for that version yet).

## Related Issue
Fixes #688.

## Motivation and Context
This library needs to depend on `@types/luxon` since we now export our own types. See the related issue for the error this fixes.

## How Has This Been Tested?
- checked that TypeScript now correctly loads the Luxon types
- ran tests locally

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
- [ ] If my change introduces a breaking change, I have added a `!` after the type/scope in the title (see the Conventional Commits standard).
