### PR TITLE
test: check at runtime that all tests call expect

### DIFF
--- a/tests/cron.test.ts
+++ b/tests/cron.test.ts
@@ -3,6 +3,9 @@ import sinon from 'sinon';
 import { CronJob, CronTime } from '../src';
 
 describe('cron', () => {
+	// eslint-disable-next-line jest/no-standalone-expect
+	afterEach(() => expect.hasAssertions());
+
 	describe('with seconds', () => {
 		it('should run every second (* * * * * *)', () => {
 			const clock = sinon.useFakeTimers();

--- a/tests/crontime.test.ts
+++ b/tests/crontime.test.ts
@@ -3,6 +3,9 @@ import sinon from 'sinon';
 import { CronTime } from '../src';
 
 describe('crontime', () => {
+	// eslint-disable-next-line jest/no-standalone-expect
+	afterEach(() => expect.hasAssertions());
+
 	it('should test stars (* * * * * *)', () => {
 		expect(() => {
 			new CronTime('* * * * * *');


### PR DESCRIPTION
## Description

Make sure every test calls `expect()`, even asynchronously.

> `(method) jest.Expect.hasAssertions(): void`
> Verifies that at least one assertion is called during a test. This is often useful when testing asynchronous code, in order to make sure that assertions in a callback actually got called.

## Related Issue

N/A

## Motivation and Context

Since we sometimes use `expect()` in the `onTick` callback, tests could pass if the callback is never called, resulting in bugs not being detected by our test suites.

## How Has This Been Tested?

Temporarily removed the `cloc.tick()` call on an asynchronous test, successfully failing the test where it was previously succeeding.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [ ] If my change introduces a breaking change, I have added a `!` after the type/scope in the title (see the Conventional Commits standard).
