### PR TITLE
fix: fix lastDate() value for intervals > 25 days

### DIFF
--- a/src/job.ts
+++ b/src/job.ts
@@ -243,7 +243,6 @@ export class CronJob<OC extends CronOnCompleteCommand<C> | null, C = null> {
 			// again. This processing might make us miss the deadline by a few ms
 			// times the number of sleep sessions. Given a MAXDELAY of almost a
 			// month, this should be no issue.
-			this.lastExecution = new Date();
 			if (remaining) {
 				if (remaining > MAXDELAY) {
 					remaining -= MAXDELAY;
@@ -256,6 +255,7 @@ export class CronJob<OC extends CronOnCompleteCommand<C> | null, C = null> {
 				setCronTimeout(timeout);
 			} else {
 				// We have arrived at the correct point in time.
+				this.lastExecution = new Date();
 
 				this.running = false;
 

--- a/tests/cron.test.ts
+++ b/tests/cron.test.ts
@@ -1108,7 +1108,7 @@ describe('cron', () => {
 		clock.restore();
 	});
 
-	it('should give the last execution date', () => {
+	it('should give the correct last execution date', () => {
 		const callback = jest.fn();
 		const clock = sinon.useFakeTimers();
 		const job = new CronJob('* * * * * *', callback);
@@ -1116,6 +1116,23 @@ describe('cron', () => {
 		clock.tick(1000);
 		expect(callback).toHaveBeenCalledTimes(1);
 		expect(job.lastDate()?.getTime()).toBe(1000);
+		job.stop();
+		clock.restore();
+	});
+
+	it('should give the correct last execution date for intervals greater than 25 days (#710)', () => {
+		const callback = jest.fn();
+		const clock = sinon.useFakeTimers();
+
+		const job = new CronJob('0 0 0 1 * *', callback); // At 00:00 on day-of-month 1.
+		job.start();
+
+		// tick one tick before nextDate()
+		clock.tick(job.nextDate().toMillis() - 1);
+
+		expect(callback).toHaveBeenCalledTimes(0);
+		expect(job.lastDate()?.getTime()).toBeUndefined();
+
 		job.stop();
 		clock.restore();
 	});


### PR DESCRIPTION
## Description

Update the internal `lastExecution` variable when running `onTick`, not when checking if we should run `onTick` or set a new timeout.

## Related Issue

Fixes https://github.com/kelektiv/node-cron/issues/710.

## Motivation and Context

See related issue.

## How Has This Been Tested?

Added test case. See [the failing test workflow](https://github.com/kelektiv/node-cron/actions/runs/6382788543/job/17322106840?pr=711) before pushing the fix.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [ ] If my change introduces a breaking change, I have added a `!` after the type/scope in the title (see the Conventional Commits standard).
