### PR TITLE
ci(renovate): update configuration

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,18 +1,58 @@
 {
 	"$schema": "https://docs.renovatebot.com/renovate-schema.json",
 	"extends": [
-		"config:base",
+		"config:recommended",
 		":dependencyDashboard",
 		":disableRateLimiting",
 		":pinOnlyDevDependencies",
 		"npm:unpublishSafe",
 		"docker:pinDigests",
-		"helpers:pinGitHubActionDigests"
+		"helpers:pinGitHubActionDigests",
+		"security:openssf-scorecard"
+	],
+	"ignorePresets": [
+		":semanticPrefixFixDepsChoreOthers",
+		"group:semantic-releaseMonorepo",
+		"group:commitlintMonorepo"
 	],
 	"schedule": ["before 5am every weekday", "every weekend"],
 	"lockFileMaintenance": { "enabled": true, "automerge": true },
 	"labels": ["dependencies"],
+	"osvVulnerabilityAlerts": true,
 	"packageRules": [
+		{
+			"matchPackagePatterns": ["*"],
+			"semanticCommitType": "chore"
+		},
+		{
+			"matchDepTypes": ["dependencies"],
+			"semanticCommitType": "build"
+		},
+		{
+			"matchDepTypes": ["action"],
+			"semanticCommitType": "ci",
+			"semanticCommitScope": "action"
+		},
+
+		{
+			"extends": ["monorepo:semantic-release"],
+			"groupName": "semantic-release related packages",
+			"matchUpdateTypes": ["digest", "patch", "minor", "major"]
+		},
+		{
+			"extends": ["monorepo:commitlint"],
+			"groupName": "semantic-release related packages",
+			"matchUpdateTypes": ["digest", "patch", "minor", "major"]
+		},
+		{
+			"matchPackagePatterns": [
+				"@insurgentlab/conventional-changelog-preset",
+				"@insurgentlab/commitlint-config"
+			],
+			"groupName": "semantic-release related packages",
+			"matchUpdateTypes": ["digest", "patch", "minor", "major"]
+		},
+
 		{
 			"extends": ["packages:linters"],
 			"groupName": "linters",
@@ -23,15 +63,11 @@
 			"groupName": "tests",
 			"addLabels": ["tests"]
 		},
+
 		{
 			"matchDepTypes": ["devDependencies"],
 			"matchUpdateTypes": ["minor", "patch"],
 			"automerge": true
-		},
-		{
-			"matchDepTypes": ["action"],
-			"semanticCommitType": "ci",
-			"semanticCommitScope": "action"
 		}
 	]
 }


### PR DESCRIPTION
## Description

this PR updates Renovate configuration as follow:

- migrate `config:base` to `config:recommended` (name change in Renovate, same behavior)
- enable [`security:openssf-scorecard` preset](https://docs.renovatebot.com/presets-security/#securityopenssf-scorecard)
- enable [`osvVulnerabilityAlerts` option](https://docs.renovatebot.com/configuration-options/#osvvulnerabilityalerts)
- use `build` commit type for dependencies instead of `fix` (as specified in [most semantic](https://github.com/insurgent-lab/conventional-changelog-preset#commit-types) [commit types](https://github.com/angular/angular/blob/92113d73dd38d0285e25e8d678c240cf4aa8834a/CONTRIBUTING.md#type) conventions)
- merge `monorepo:semantic-release`, `monorepo:commitlint`, `@insurgentlab/conventional-changelog-preset` and `@insurgentlab/commitlint-config` in a single group ("semantic-release related packages")