### PR TITLE
fix: allow callbacks to return a promise

### DIFF
--- a/src/job.ts
+++ b/src/job.ts
@@ -155,7 +155,7 @@ export class CronJob<OC extends CronOnCompleteCommand | null = null, C = null> {
 			case 'string': {
 				const [command, ...args] = cmd.split(' ');
 
-				return spawn.bind(undefined, command ?? cmd, args, {});
+				return spawn.bind(undefined, command ?? cmd, args, {}) as () => void;
 			}
 
 			case 'object': {
@@ -164,7 +164,7 @@ export class CronJob<OC extends CronOnCompleteCommand | null = null, C = null> {
 					cmd.command,
 					cmd.args ?? [],
 					cmd.options ?? {}
-				);
+				) as () => void;
 			}
 		}
 	}
@@ -191,7 +191,7 @@ export class CronJob<OC extends CronOnCompleteCommand | null = null, C = null> {
 
 	fireOnTick() {
 		for (const callback of this._callbacks) {
-			callback.call(
+			void callback.call(
 				this.context,
 				this.onComplete as WithOnComplete<OC> extends true
 					? CronOnCompleteCallback
@@ -293,7 +293,7 @@ export class CronJob<OC extends CronOnCompleteCommand | null = null, C = null> {
 		if (this._timeout) clearTimeout(this._timeout);
 		this.running = false;
 		if (typeof this.onComplete === 'function') {
-			this.onComplete.call(this.context);
+			void this.onComplete.call(this.context);
 		}
 	}
 }

--- a/src/types/cron.types.ts
+++ b/src/types/cron.types.ts
@@ -37,9 +37,9 @@ export type CronContext<C> = C extends null ? CronJob : NonNullable<C>;
 export type CronCallback<C, WithOnCompleteBool extends boolean = false> = (
 	this: CronContext<C>,
 	onComplete: WithOnCompleteBool extends true ? CronOnCompleteCallback : never
-) => void;
+) => void | Promise<void>;
 
-export type CronOnCompleteCallback = () => void;
+export type CronOnCompleteCallback = () => void | Promise<void>;
 
 export type CronSystemCommand =
 	| string

--- a/tests/cron.test.ts
+++ b/tests/cron.test.ts
@@ -327,7 +327,7 @@ describe('cron', () => {
 					onComplete => {
 						const t = new Date();
 						expect(t.getSeconds()).toBe(d.getSeconds());
-						onComplete();
+						void onComplete();
 					},
 					() => {
 						callback();
@@ -356,7 +356,7 @@ describe('cron', () => {
 					onTick: onComplete => {
 						const t = new Date();
 						expect(t.getSeconds()).toBe(d.getSeconds());
-						onComplete();
+						void onComplete();
 					},
 					onComplete: function () {
 						callback();
@@ -1192,5 +1192,27 @@ describe('cron', () => {
 				utcOffset: 120
 			});
 		}).toThrow();
+	});
+
+	it('should support async callback', () => {
+		const clock = sinon.useFakeTimers();
+		const callback = jest.fn();
+		const job = new CronJob(
+			'* * * * * *',
+			async function () {
+				await new Promise<void>(resolve => {
+					setTimeout(() => {
+						callback();
+						resolve();
+					}, 500);
+				});
+			},
+			null,
+			true
+		);
+		clock.tick(1500);
+		job.stop();
+		clock.restore();
+		expect(callback).toHaveBeenCalledTimes(1);
 	});
 });


### PR DESCRIPTION
## Description

this is a type-only change that allows callbacks to return a promise. this was already possible before migrating the codebase to TypeScript, but it wasn't reflected correctly in our typings.

## Related Issue

N/A

## Motivation and Context

while working on the `@nestjs/schedule` PR to upgrade to `cron@3.x`, I got a SonarLint warning about passing an async function to onTick.

## How Has This Been Tested?

added test case with async `onTick`.

## Screenshots (if appropriate):

![image](https://github.com/kelektiv/node-cron/assets/11234273/f8d8c456-bd72-4eeb-9a79-9a80d86fb5b1)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [ ] If my change introduces a breaking change, I have added a `!` after the type/scope in the title (see the Conventional Commits standard).
