### PR TITLE
fix: set runOnce when actual date is given to setTime

### DIFF
--- a/src/job.ts
+++ b/src/job.ts
@@ -16,7 +16,6 @@ export class CronJob<OC extends CronOnCompleteCommand | null = null, C = null> {
 	running = false;
 	unrefTimeout = false;
 	lastExecution: Date | null = null;
-	runOnce = false;
 	context: CronContext<C>;
 	onComplete?: WithOnComplete<OC> extends true
 		? CronOnCompleteCallback
@@ -82,10 +81,6 @@ export class CronJob<OC extends CronOnCompleteCommand | null = null, C = null> {
 			this.onComplete = this._fnWrap(
 				onComplete
 			) as WithOnComplete<OC> extends true ? CronOnCompleteCallback : undefined;
-		}
-
-		if (this.cronTime.realDate) {
-			this.runOnce = true;
 		}
 
 		this.addCallback(this._fnWrap(onTick));
@@ -183,9 +178,6 @@ export class CronJob<OC extends CronOnCompleteCommand | null = null, C = null> {
 		this.stop();
 
 		this.cronTime = time;
-		if (this.cronTime.realDate) {
-			this.runOnce = true;
-		}
 
 		if (wasRunning) this.start();
 	}
@@ -263,7 +255,7 @@ export class CronJob<OC extends CronOnCompleteCommand | null = null, C = null> {
 				this.running = false;
 
 				// start before calling back so the callbacks have the ability to stop the cron job
-				if (!this.runOnce) {
+				if (!this.cronTime.realDate) {
 					this.start();
 				}
 

--- a/src/job.ts
+++ b/src/job.ts
@@ -181,7 +181,12 @@ export class CronJob<OC extends CronOnCompleteCommand | null = null, C = null> {
 		}
 		const wasRunning = this.running;
 		this.stop();
+
 		this.cronTime = time;
+		if (this.cronTime.realDate) {
+			this.runOnce = true;
+		}
+
 		if (wasRunning) this.start();
 	}
 

--- a/src/time.ts
+++ b/src/time.ts
@@ -684,7 +684,7 @@ export class CronTime {
 		return true;
 	}
 
-	/*
+	/**
 	 * Parse the cron syntax into something useful for selecting the next execution time.
 	 *
 	 * Algorithm:
@@ -733,7 +733,7 @@ export class CronTime {
 		}
 	}
 
-	/*
+	/**
 	 * Parse individual field from the cron syntax provided.
 	 *
 	 * Algorithm:

--- a/tests/cron.test.ts
+++ b/tests/cron.test.ts
@@ -1080,6 +1080,29 @@ describe('cron', () => {
 			job.stop();
 			expect(callback).toHaveBeenCalledTimes(1);
 		});
+
+		it('should create recurring job, setTime with actual date, start and run once (#739)', () => {
+			const callback = jest.fn();
+			const clock = sinon.useFakeTimers();
+
+			const job = new CronJob('0 0 20 * * *', callback);
+
+			const startDate = new Date(Date.now() + 5000);
+			job.setTime(new CronTime(startDate));
+
+			job.start();
+
+			clock.tick(5000);
+
+			expect(callback).toHaveBeenCalledTimes(1);
+
+			clock.tick(60000);
+
+			clock.restore();
+
+			expect(callback).toHaveBeenCalledTimes(1);
+			expect(job.running).toBe(false);
+		});
 	});
 
 	describe('nextDate(s)', () => {


### PR DESCRIPTION
## Description

initially, set the internal variable `runOnce` correctly when passing an actual date to `setTime`. previously this was only done in the constructor.

since it is only used in [one place](https://github.com/kelektiv/node-cron/blob/24f31caf4dd180d834f4f3ead2576cb80de9a4b8/src/job.ts#L261) and as to limit this kind of error, I then removed the `runOnce` property completely (we now check directly if `this.cronTime` is a real date). we do not consider this a breaking change since it was not referenced in the API documentation).

## Related Issue

Fixes #739.

## Motivation and Context

Fixes an issue when after creating a job with a cron expression and using `setTime` with an actual date, the job attempts to run multiple times.

## How Has This Been Tested?

added test case provided by #739's OP.

## Screenshots (if appropriate):

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [ ] If my change introduces a breaking change, I have added a `!` after the type/scope in the title (see the Conventional Commits standard).
