### PR TITLE
fix: re-add runOnce property to CronJob

### DIFF
--- a/src/job.ts
+++ b/src/job.ts
@@ -21,6 +21,10 @@ export class CronJob<OC extends CronOnCompleteCommand | null = null, C = null> {
 		? CronOnCompleteCallback
 		: undefined;
 
+	get runOnce(): boolean {
+		return this.cronTime.realDate;
+	}
+
 	private _timeout?: NodeJS.Timeout;
 	private _callbacks: CronCallback<C, WithOnComplete<OC>>[] = [];
 
@@ -255,7 +259,7 @@ export class CronJob<OC extends CronOnCompleteCommand | null = null, C = null> {
 				this.running = false;
 
 				// start before calling back so the callbacks have the ability to stop the cron job
-				if (!this.cronTime.realDate) {
+				if (!this.runOnce) {
 					this.start();
 				}
 


### PR DESCRIPTION
## Description

add `runOnce` back to CronJob, this time as a getter to shadowing `this.cronTime.realDate` value.

## Related Issue

https://github.com/kelektiv/node-cron/pull/740#issuecomment-1777662358

## Motivation and Context

removing this property was a breaking change.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [ ] If my change introduces a breaking change, I have added a `!` after the type/scope in the title (see the Conventional Commits standard).
