### PR TITLE
fix: revert runOnce breaking changes

### DIFF
--- a/src/job.ts
+++ b/src/job.ts
@@ -16,6 +16,7 @@ export class CronJob<OC extends CronOnCompleteCommand | null = null, C = null> {
 	running = false;
 	unrefTimeout = false;
 	lastExecution: Date | null = null;
+	runOnce = false;
 	context: CronContext<C>;
 	onComplete?: WithOnComplete<OC> extends true
 		? CronOnCompleteCallback
@@ -81,6 +82,10 @@ export class CronJob<OC extends CronOnCompleteCommand | null = null, C = null> {
 			this.onComplete = this._fnWrap(
 				onComplete
 			) as WithOnComplete<OC> extends true ? CronOnCompleteCallback : undefined;
+		}
+
+		if (this.cronTime.realDate) {
+			this.runOnce = true;
 		}
 
 		this.addCallback(this._fnWrap(onTick));
@@ -176,9 +181,7 @@ export class CronJob<OC extends CronOnCompleteCommand | null = null, C = null> {
 		}
 		const wasRunning = this.running;
 		this.stop();
-
 		this.cronTime = time;
-
 		if (wasRunning) this.start();
 	}
 
@@ -255,7 +258,7 @@ export class CronJob<OC extends CronOnCompleteCommand | null = null, C = null> {
 				this.running = false;
 
 				// start before calling back so the callbacks have the ability to stop the cron job
-				if (!this.cronTime.realDate) {
+				if (!this.runOnce) {
 					this.start();
 				}
 

--- a/src/job.ts
+++ b/src/job.ts
@@ -21,10 +21,6 @@ export class CronJob<OC extends CronOnCompleteCommand | null = null, C = null> {
 		? CronOnCompleteCallback
 		: undefined;
 
-	get runOnce(): boolean {
-		return this.cronTime.realDate;
-	}
-
 	private _timeout?: NodeJS.Timeout;
 	private _callbacks: CronCallback<C, WithOnComplete<OC>>[] = [];
 
@@ -259,7 +255,7 @@ export class CronJob<OC extends CronOnCompleteCommand | null = null, C = null> {
 				this.running = false;
 
 				// start before calling back so the callbacks have the ability to stop the cron job
-				if (!this.runOnce) {
+				if (!this.cronTime.realDate) {
 					this.start();
 				}
 

--- a/src/job.ts
+++ b/src/job.ts
@@ -179,9 +179,13 @@ export class CronJob<OC extends CronOnCompleteCommand | null = null, C = null> {
 		if (!(time instanceof CronTime)) {
 			throw new CronError('time must be an instance of CronTime.');
 		}
+
 		const wasRunning = this.running;
 		this.stop();
+
 		this.cronTime = time;
+		if (time.realDate) this.runOnce = true;
+
 		if (wasRunning) this.start();
 	}
 

--- a/src/time.ts
+++ b/src/time.ts
@@ -84,7 +84,7 @@ export class CronTime {
 		return date.weekday === 7 ? 0 : date.weekday;
 	}
 
-	/*
+	/**
 	 * Ensure that the syntax parsed correctly and correct the specified values if needed.
 	 */
 	private _verifyParse() {
@@ -684,7 +684,7 @@ export class CronTime {
 		return true;
 	}
 
-	/*
+	/**
 	 * Parse the cron syntax into something useful for selecting the next execution time.
 	 *
 	 * Algorithm:
@@ -733,7 +733,7 @@ export class CronTime {
 		}
 	}
 
-	/*
+	/**
 	 * Parse individual field from the cron syntax provided.
 	 *
 	 * Algorithm:
@@ -762,7 +762,7 @@ export class CronTime {
 			}
 		});
 
-		// * is a shortcut to [low-high] range for the field
+		// "*" is a shortcut to [low-high] range for the field
 		value = value.replace(RE_WILDCARDS, `${low}-${high}`);
 
 		// commas separate information, so split based on those

--- a/src/time.ts
+++ b/src/time.ts
@@ -684,7 +684,7 @@ export class CronTime {
 		return true;
 	}
 
-	/**
+	/*
 	 * Parse the cron syntax into something useful for selecting the next execution time.
 	 *
 	 * Algorithm:
@@ -733,7 +733,7 @@ export class CronTime {
 		}
 	}
 
-	/**
+	/*
 	 * Parse individual field from the cron syntax provided.
 	 *
 	 * Algorithm:

--- a/tests/cron.test.ts
+++ b/tests/cron.test.ts
@@ -1080,29 +1080,6 @@ describe('cron', () => {
 			job.stop();
 			expect(callback).toHaveBeenCalledTimes(1);
 		});
-
-		it('should create recurring job, setTime with actual date, start and run once (#739)', () => {
-			const callback = jest.fn();
-			const clock = sinon.useFakeTimers();
-
-			const job = new CronJob('0 0 20 * * *', callback);
-
-			const startDate = new Date(Date.now() + 5000);
-			job.setTime(new CronTime(startDate));
-
-			job.start();
-
-			clock.tick(5000);
-
-			expect(callback).toHaveBeenCalledTimes(1);
-
-			clock.tick(60000);
-
-			clock.restore();
-
-			expect(callback).toHaveBeenCalledTimes(1);
-			expect(job.running).toBe(false);
-		});
 	});
 
 	describe('nextDate(s)', () => {

--- a/tests/cron.test.ts
+++ b/tests/cron.test.ts
@@ -1080,6 +1080,29 @@ describe('cron', () => {
 			job.stop();
 			expect(callback).toHaveBeenCalledTimes(1);
 		});
+
+		it('should create recurring job, setTime with actual date, start and run once (#739)', () => {
+			const callback = jest.fn();
+			const clock = sinon.useFakeTimers();
+
+			const job = new CronJob('0 0 20 * * *', callback);
+
+			const startDate = new Date(Date.now() + 5000);
+			job.setTime(new CronTime(startDate));
+
+			job.start();
+
+			clock.tick(5000);
+
+			expect(callback).toHaveBeenCalledTimes(1);
+
+			clock.tick(60000);
+
+			clock.restore();
+
+			expect(callback).toHaveBeenCalledTimes(1);
+			expect(job.running).toBe(false);
+		});
 	});
 
 	describe('nextDate(s)', () => {


### PR DESCRIPTION
## Description, Motivation & Context

This PR restores the original `runOnce` property, which was changed in #740 without considering it a breaking change since it was an undocumented internal property. That was a mistake because consumers relied on it.
The property was added back *as a read-only getter* in #751, which was another naive decision from me, because not only did consumers rely on reading it, but it seems (based on the Renovate passing tests percentage below) that they actually also mutate the property to change their jobs' behavior.

> ![image](https://github.com/kelektiv/node-cron/assets/11234273/b0706eac-7c39-48cb-bb17-de6abaf559f6)


## Related Issues

- #739
- #740
- #751

## How Has This Been Tested?

Test case already present from #740.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [ ] If my change introduces a breaking change, I have added a `!` after the type/scope in the title (see the Conventional Commits standard).
