### PR TITLE
ci(action): prevent duplicate checks on Renovate PRs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,6 +15,15 @@ permissions:
   contents: read
 
 jobs:
+  # prevent duplicate checks on Renovate PRs
+  prevent-duplicate-checks:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: insurgent-lab/is-in-pr-action@cae57fda20aef9688ed4df4e48a0857e0033c90b # v0.1.3
+        id: isInPR
+    outputs:
+      should-run: ${{ !(steps.isInPR.outputs.result == 'true' && startsWith(github.ref, 'refs/heads/renovate/')) }}
+
   test_matrix:
     strategy:
       matrix:
@@ -23,6 +32,9 @@ jobs:
 
     runs-on: ${{ matrix.os }}
     timeout-minutes: 5
+
+    needs: prevent-duplicate-checks
+    if: ${{ needs.prevent-duplicate-checks.outputs.should-run == 'true' }}
 
     steps:
       - name: Harden Runner


### PR DESCRIPTION
## Description

Skip the `push` event if the workflow detects an open PR for the current commit and the branch it belongs to starts with `renovate/`. [_Example skipped `push` workflow run_](https://github.com/sheerlox/import-from-esm/actions/runs/6792854467)

## Related Issue

- https://github.com/semantic-release/.github/issues/19#issuecomment-1800911730
- https://github.com/sheerlox/import-from-esm/commit/ce97a59d514f15cb65647fa5da203c2160c34617

## Motivation and Context

Following the changes in #750, the `push` event on `renovate/**` branches and the `pull_request` event both trigger on Renovate PRs. [_Example PR with duplicate checks_](https://github.com/kelektiv/node-cron/pull/777)

## How Has This Been Tested?

The same mechanism is used in [`import-from-esm`](https://github.com/sheerlox/import-from-esm)'s [test workflow](https://github.com/sheerlox/import-from-esm/blob/29fbee73fea9a981975887503ccf1c86951313ab/.github/workflows/test.yml).
