### PR TITLE
ci: fix renovate skipping checks

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -73,8 +73,10 @@ jobs:
   required_check:
     runs-on: ubuntu-latest
     needs:
+      - prevent-duplicate-checks
       - test_matrix
-    if: always()
+
+    if: ${{ !cancelled() && needs.prevent-duplicate-checks.outputs.should-run == 'true' }}
     steps:
       - name: All required jobs and matrix versions passed
         if: ${{ !(contains(needs.*.result, 'failure')) }}


### PR DESCRIPTION
Due to a CI misconfiguration, Renovate was able to skip checks on PRs. This should fix the issue by skipping the `required_check` job, which gives the green light if the other jobs were skipped, for the `push` event.