### PR TITLE
feat: [435] add support for extended cron syntax

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -79,3 +79,4 @@ export const PRESETS = Object.freeze({
 } as const);
 export const RE_WILDCARDS = /\*/g;
 export const RE_RANGE = /^(\d+)(?:-(\d+))?(?:\/(\d+))?$/g;
+export const RE_QUESTIONMARK = /\?/g;

--- a/src/time.ts
+++ b/src/time.ts
@@ -6,6 +6,7 @@ import {
 	MONTH_CONSTRAINTS,
 	PARSE_DEFAULTS,
 	PRESETS,
+	RE_QUESTIONMARK,
 	RE_RANGE,
 	RE_WILDCARDS,
 	TIME_UNITS,
@@ -721,6 +722,9 @@ export class CronTime {
 			throw new CronError('Too many fields');
 		}
 
+		//timestamp for eventual '?' substitution
+		const now = DateTime.local();
+
 		const unitsLen = units.length;
 		for (const unit of TIME_UNITS) {
 			const i = TIME_UNITS.indexOf(unit);
@@ -729,7 +733,7 @@ export class CronTime {
 			// This adds support for 5-digit standard cron syntax
 			const cur =
 				units[i - (TIME_UNITS_LEN - unitsLen)] ?? PARSE_DEFAULTS[unit];
-			this._parseField(cur, unit);
+			this._parseField(cur, unit, now);
 		}
 	}
 
@@ -744,7 +748,7 @@ export class CronTime {
 	 *   - Starting with the lower bounds of the range iterate by step up to the upper bounds and toggle the CronTime field value flag on.
 	 */
 
-	private _parseField(value: string, unit: TimeUnit) {
+	private _parseField(value: string, unit: TimeUnit, now: DateTime) {
 		const typeObj = this[unit] as TimeUnitField<typeof unit>;
 		let pointer: Ranges[typeof unit];
 
@@ -761,6 +765,9 @@ export class CronTime {
 				);
 			}
 		});
+
+		// "?" will be replaced with current timestamp value
+		value = value.replace(RE_QUESTIONMARK, this._getTimeUnit(now, unit));
 
 		// "*" is a shortcut to [low-high] range for the field
 		value = value.replace(RE_WILDCARDS, `${low}-${high}`);
@@ -824,6 +831,25 @@ export class CronTime {
 			} else {
 				throw new CronError(`Field (${unit}) cannot be parsed`);
 			}
+		}
+	}
+
+	private _getTimeUnit(now: DateTime, unit: TimeUnit) {
+		switch (unit) {
+			case 'second':
+				return now.second.toString();
+			case 'minute':
+				return now.minute.toString();
+			case 'hour':
+				return now.hour.toString();
+			case 'dayOfMonth':
+				return now.day.toString();
+			case 'month':
+				return now.month.toString();
+			case 'dayOfWeek':
+				return this._getWeekDay(now).toString();
+			default:
+				throw new CronError('Invalid time unit');
 		}
 	}
 }

--- a/tests/crontime.test.ts
+++ b/tests/crontime.test.ts
@@ -775,4 +775,72 @@ describe('crontime', () => {
 			new CronTime('* * * * *', 'Asia/Amman', 120);
 		}).toThrow();
 	});
+
+	describe('should support question mark', () => {
+		it('should substitute minute', () => {
+			const clock = sinon.useFakeTimers();
+
+			const now = DateTime.local();
+			const ct = new CronTime('? * * * *');
+			const minutes = ct.sendAt().get('minute');
+			expect(minutes).toBe(now.get('minute'));
+
+			clock.restore();
+		});
+
+		it('should substitute seconds', () => {
+			const clock = sinon.useFakeTimers();
+
+			const now = DateTime.local();
+			const ct = new CronTime('? * * * * *');
+			const second = ct.sendAt().get('second');
+			expect(second).toBe(now.get('second'));
+
+			clock.restore();
+		});
+
+		it('should substitute hours', () => {
+			const clock = sinon.useFakeTimers();
+
+			const now = DateTime.local();
+			const ct = new CronTime('* ? * * *');
+			const hour = ct.sendAt().get('hour');
+			expect(hour).toBe(now.get('hour'));
+
+			clock.restore();
+		});
+
+		it('should substitute day', () => {
+			const clock = sinon.useFakeTimers();
+
+			const now = DateTime.local();
+			const ct = new CronTime('* * ? * *');
+			const day = ct.sendAt().get('day');
+			expect(day).toBe(now.get('day'));
+
+			clock.restore();
+		});
+
+		it('should substitute month', () => {
+			const clock = sinon.useFakeTimers();
+
+			const now = DateTime.local();
+			const ct = new CronTime('* * * ? *');
+			const month = ct.sendAt().get('month');
+			expect(month).toBe(now.get('month'));
+
+			clock.restore();
+		});
+
+		it('should substitute dayOfWeek', () => {
+			const clock = sinon.useFakeTimers();
+
+			const now = DateTime.local();
+			const ct = new CronTime('* * * * ?');
+			const month = ct.sendAt().get('weekday');
+			expect(month).toBe(now.get('weekday'));
+
+			clock.restore();
+		});
+	});
 });


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above (following the Conventional Commits standard) -->
<!-- More infos: https://www.conventionalcommits.org -->
<!-- Commit types: https://github.com/insurgent-lab/conventional-changelog-preset#commit-types-->

## Description

<!--- Describe your changes in detail -->

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
#435 

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Added more unit tests.

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [ ] If my change introduces a breaking change, I have added a `!` after the type/scope in the title (see the Conventional Commits standard).
