### PR TITLE
fix: midnight cron not executing

### DIFF
--- a/tests/cron.test.ts
+++ b/tests/cron.test.ts
@@ -829,7 +829,7 @@ describe('cron', () => {
 		const clock = sinon.useFakeTimers(d.getTime());
 
 		const job = CronJob.from({
-			cronTime: '00 * * * * *',
+			cronTime: '00 00 * * *',
 			onTick: callback,
 			start: true,
 			timeZone: 'UTC'

--- a/tests/cron.test.ts
+++ b/tests/cron.test.ts
@@ -831,8 +831,7 @@ describe('cron', () => {
 		const job = CronJob.from({
 			cronTime: '00 00 * * *',
 			onTick: callback,
-			start: true,
-			timeZone: 'UTC'
+			start: true
 		});
 
 		clock.tick(1000); // move clock 1 second
@@ -843,12 +842,12 @@ describe('cron', () => {
 		expect(callback).toHaveBeenCalledTimes(1);
 	});
 
-	it('should run every day UTC', () => {
+	it('should run every day at 12:30 UTC', () => {
 		const callback = jest.fn();
 		const d = new Date('12/31/2014');
-		d.setSeconds(0);
-		d.setMinutes(0);
-		d.setHours(0);
+		d.setUTCSeconds(0);
+		d.setUTCMinutes(0);
+		d.setUTCHours(0);
 		const clock = sinon.useFakeTimers(d.getTime());
 
 		const job = CronJob.from({


### PR DESCRIPTION
## Description

WIP

## Related Issue

https://github.com/kelektiv/node-cron/issues/400

## Motivation and Context

When scheduling a cron job at midnight everyday (`00 00 * * *`), it doesn't get executed.

## How Has This Been Tested?

Fixed the cron pattern in the test that was supposed to cover this use case.

## Screenshots (if appropriate):

## Types of changes

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] If my change introduces a breaking change, I have added a `!` after the type/scope in the title (see the Conventional Commits standard).
