### PR TITLE
ci: allow Renovate to auto-merge minor and patch dependency version updates

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -15,77 +15,45 @@
 		"group:semantic-releaseMonorepo",
 		"group:commitlintMonorepo"
 	],
-	"schedule": [
-		"before 5am every weekday",
-		"every weekend"
-	],
+	"schedule": ["before 5am every weekday", "every weekend"],
 	"lockFileMaintenance": {
 		"enabled": true,
 		"automerge": true,
 		"automergeType": "branch"
 	},
-	"labels": [
-		"dependencies"
-	],
+	"labels": ["dependencies"],
 	"osvVulnerabilityAlerts": true,
 	"packageRules": [
 		{
-			"matchPackagePatterns": [
-				"*"
-			],
+			"matchPackagePatterns": ["*"],
 			"semanticCommitType": "chore"
 		},
 		{
-			"matchDepTypes": [
-				"dependencies"
-			],
-			"matchUpdateTypes": [
-				"minor",
-				"patch"
-			],
+			"matchDepTypes": ["dependencies"],
+			"matchUpdateTypes": ["minor", "patch"],
 			"semanticCommitType": "build",
 			"automerge": true,
 			"automergeType": "branch"
 		},
 		{
-			"matchDepTypes": [
-				"dependencies"
-			],
-			"matchUpdateTypes": [
-				"major"
-			],
+			"matchDepTypes": ["dependencies"],
+			"matchUpdateTypes": ["major"],
 			"semanticCommitType": "build"
 		},
 		{
-			"matchDepTypes": [
-				"action"
-			],
+			"matchDepTypes": ["action"],
 			"semanticCommitType": "ci",
 			"semanticCommitScope": "action"
 		},
 		{
-			"extends": [
-				"monorepo:semantic-release"
-			],
+			"extends": ["monorepo:semantic-release"],
 			"groupName": "semantic-release related packages",
-			"matchUpdateTypes": [
-				"digest",
-				"patch",
-				"minor",
-				"major"
-			]
+			"matchUpdateTypes": ["digest", "patch", "minor", "major"]
 		},
 		{
-			"extends": [
-				"monorepo:commitlint"
-			],
+			"extends": ["monorepo:commitlint"],
 			"groupName": "semantic-release related packages",
-			"matchUpdateTypes": [
-				"digest",
-				"patch",
-				"minor",
-				"major"
-			]
+			"matchUpdateTypes": ["digest", "patch", "minor", "major"]
 		},
 		{
 			"matchPackagePatterns": [
@@ -93,39 +61,21 @@
 				"@insurgent/commitlint-config"
 			],
 			"groupName": "semantic-release related packages",
-			"matchUpdateTypes": [
-				"digest",
-				"patch",
-				"minor",
-				"major"
-			]
+			"matchUpdateTypes": ["digest", "patch", "minor", "major"]
 		},
 		{
-			"extends": [
-				"packages:linters"
-			],
+			"extends": ["packages:linters"],
 			"groupName": "linters",
-			"addLabels": [
-				"linters"
-			]
+			"addLabels": ["linters"]
 		},
 		{
-			"extends": [
-				"packages:test"
-			],
+			"extends": ["packages:test"],
 			"groupName": "tests",
-			"addLabels": [
-				"tests"
-			]
+			"addLabels": ["tests"]
 		},
 		{
-			"matchDepTypes": [
-				"devDependencies"
-			],
-			"matchUpdateTypes": [
-				"minor",
-				"patch"
-			],
+			"matchDepTypes": ["devDependencies"],
+			"matchUpdateTypes": ["minor", "patch"],
 			"automerge": true,
 			"automergeType": "branch"
 		}

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -15,38 +15,77 @@
 		"group:semantic-releaseMonorepo",
 		"group:commitlintMonorepo"
 	],
-	"schedule": ["before 5am every weekday", "every weekend"],
+	"schedule": [
+		"before 5am every weekday",
+		"every weekend"
+	],
 	"lockFileMaintenance": {
 		"enabled": true,
 		"automerge": true,
 		"automergeType": "branch"
 	},
-	"labels": ["dependencies"],
+	"labels": [
+		"dependencies"
+	],
 	"osvVulnerabilityAlerts": true,
 	"packageRules": [
 		{
-			"matchPackagePatterns": ["*"],
+			"matchPackagePatterns": [
+				"*"
+			],
 			"semanticCommitType": "chore"
 		},
 		{
-			"matchDepTypes": ["dependencies"],
+			"matchDepTypes": [
+				"dependencies"
+			],
+			"matchUpdateTypes": [
+				"minor",
+				"patch"
+			],
+			"semanticCommitType": "build",
+			"automerge": true,
+			"automergeType": "branch"
+		},
+		{
+			"matchDepTypes": [
+				"dependencies"
+			],
+			"matchUpdateTypes": [
+				"major"
+			],
 			"semanticCommitType": "build"
 		},
 		{
-			"matchDepTypes": ["action"],
+			"matchDepTypes": [
+				"action"
+			],
 			"semanticCommitType": "ci",
 			"semanticCommitScope": "action"
 		},
-
 		{
-			"extends": ["monorepo:semantic-release"],
+			"extends": [
+				"monorepo:semantic-release"
+			],
 			"groupName": "semantic-release related packages",
-			"matchUpdateTypes": ["digest", "patch", "minor", "major"]
+			"matchUpdateTypes": [
+				"digest",
+				"patch",
+				"minor",
+				"major"
+			]
 		},
 		{
-			"extends": ["monorepo:commitlint"],
+			"extends": [
+				"monorepo:commitlint"
+			],
 			"groupName": "semantic-release related packages",
-			"matchUpdateTypes": ["digest", "patch", "minor", "major"]
+			"matchUpdateTypes": [
+				"digest",
+				"patch",
+				"minor",
+				"major"
+			]
 		},
 		{
 			"matchPackagePatterns": [
@@ -54,23 +93,39 @@
 				"@insurgent/commitlint-config"
 			],
 			"groupName": "semantic-release related packages",
-			"matchUpdateTypes": ["digest", "patch", "minor", "major"]
+			"matchUpdateTypes": [
+				"digest",
+				"patch",
+				"minor",
+				"major"
+			]
 		},
-
 		{
-			"extends": ["packages:linters"],
+			"extends": [
+				"packages:linters"
+			],
 			"groupName": "linters",
-			"addLabels": ["linters"]
+			"addLabels": [
+				"linters"
+			]
 		},
 		{
-			"extends": ["packages:test"],
+			"extends": [
+				"packages:test"
+			],
 			"groupName": "tests",
-			"addLabels": ["tests"]
+			"addLabels": [
+				"tests"
+			]
 		},
-
 		{
-			"matchDepTypes": ["devDependencies"],
-			"matchUpdateTypes": ["minor", "patch"],
+			"matchDepTypes": [
+				"devDependencies"
+			],
+			"matchUpdateTypes": [
+				"minor",
+				"patch"
+			],
 			"automerge": true,
 			"automergeType": "branch"
 		}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above (following the Conventional Commits standard) -->
<!-- More infos: https://www.conventionalcommits.org -->
<!-- Commit types: https://github.com/insurgent-lab/conventional-changelog-preset#commit-types-->

## Description

<!--- Describe your changes in detail -->
Previously Renovate would not automatically merge any package dependency version updates. This change allows Renovate to auto-merge minor and patch version updates.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
This change will cut down on PR and notification noise, making maintenance easier.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] If my change introduces a breaking change, I have added a `!` after the type/scope in the title (see the Conventional Commits standard).
