### PR TITLE
build(typescript): add missing "types" property to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
 		"type": "git",
 		"url": "https://github.com/kelektiv/node-cron.git"
 	},
-	"main": "dist/index",
+	"main": "dist/index.js",
+	"types": "dist/index.d.ts",
 	"scripts": {
 		"build": "tsc -b tsconfig.build.json",
 		"lint:eslint": "eslint src/ tests/ --ext .ts",


### PR DESCRIPTION
## Description

See related issue.

## Related Issue

https://github.com/kelektiv/node-cron/issues/906

## Motivation and Context

## How Has This Been Tested?

Untested, just followed the TypeScript doc: https://www.typescriptlang.org/docs/handbook/declaration-files/publishing.html#including-declarations-in-your-npm-package

## Screenshots (if appropriate):

## Types of changes

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
- [ ] If my change introduces a breaking change, I have added a `!` after the type/scope in the title (see the Conventional Commits standard).
