### PR TITLE
chore(renovate): improve schedules & automerging to reduce noise

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -25,8 +25,22 @@
 	"osvVulnerabilityAlerts": true,
 	"packageRules": [
 		{
+			"matchPackageNames": ["*"],
 			"semanticCommitType": "chore",
-			"matchPackageNames": ["*"]
+			"semanticCommitScope": "deps",
+			"schedule": "* * 10,25 * *"
+		},
+		{
+			"matchDepTypes": ["devDependencies"],
+			"matchUpdateTypes": ["minor", "patch", "pin", "pinDigest"],
+			"automerge": true,
+			"automergeType": "branch"
+		},
+		{
+			"matchDepTypes": ["dependencies"],
+			"semanticCommitType": "build",
+			"semanticCommitScope": "deps",
+			"schedule": "at any time"
 		},
 		{
 			"matchDepTypes": ["dependencies"],
@@ -36,14 +50,16 @@
 			"automergeType": "branch"
 		},
 		{
-			"matchDepTypes": ["dependencies"],
-			"matchUpdateTypes": ["major"],
-			"semanticCommitType": "build"
+			"matchManagers": ["github-actions"],
+			"semanticCommitType": "chore",
+			"semanticCommitScope": "action",
+			"schedule": "* * 10,25 * *"
 		},
 		{
-			"matchDepTypes": ["action"],
-			"semanticCommitType": "ci",
-			"semanticCommitScope": "action"
+			"matchManagers": ["github-actions"],
+			"matchUpdateTypes": ["minor", "patch", "pin", "pinDigest"],
+			"automerge": true,
+			"automergeType": "branch"
 		},
 		{
 			"extends": ["monorepo:semantic-release"],


### PR DESCRIPTION
## Description

- Automerge dev dependencies & GitHub actions (except majors).
- Set dev dependencies & GitHub actions schedule: `on the 10th and 25th day of month`
- Preserve prod dependencies schedule: `at any time`
- Use `chore(action)` commit type & scope instead of `ci(action)` for GitHub actions

## Related Issue

N/A

## Motivation and Context

Too much superfluous notifications.

This is a reproduction of one of many improvements I've made to my shared configs, [see here for the full list](https://github.com/insurgent-lab/.github/commits/main/renovate?since=2024-12-25&until=2025-01-01).

## How Has This Been Tested?

N/A

## Screenshots (if appropriate):

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
- [ ] If my change introduces a breaking change, I have added a `!` after the type/scope in the title (see the Conventional Commits standard).
