### PR TITLE
fix: timezone should default to local

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -30,6 +30,7 @@
 				"@types/node": "22.13.11",
 				"@types/sinon": "17.0.4",
 				"chai": "5.2.0",
+				"cross-env": "^7.0.3",
 				"eslint": "8.57.1",
 				"eslint-config-prettier": "9.1.0",
 				"eslint-plugin-jest": "27.9.0",
@@ -4910,6 +4911,25 @@
 			},
 			"funding": {
 				"url": "https://github.com/chalk/chalk?sponsor=1"
+			}
+		},
+		"node_modules/cross-env": {
+			"version": "7.0.3",
+			"resolved": "https://registry.npmjs.org/cross-env/-/cross-env-7.0.3.tgz",
+			"integrity": "sha512-+/HKd6EgcQCJGh2PSjZuUitQBQynKor4wrFbRg4DtAgS1aWO+gU52xpH7M9ScGgXSYmAVS9bIJ8EzuaGw0oNAw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"cross-spawn": "^7.0.1"
+			},
+			"bin": {
+				"cross-env": "src/bin/cross-env.js",
+				"cross-env-shell": "src/bin/cross-env-shell.js"
+			},
+			"engines": {
+				"node": ">=10.14",
+				"npm": ">=6",
+				"yarn": ">=1"
 			}
 		},
 		"node_modules/cross-spawn": {

--- a/package.json
+++ b/package.json
@@ -18,9 +18,9 @@
 		"lint:prettier": "prettier ./**/*.{json,md,yml} --check",
 		"lint": "npm run lint:eslint && npm run lint:prettier",
 		"lint:fix": "npm run lint:eslint -- --fix && npm run lint:prettier -- --write",
-		"test": "jest --coverage",
-		"test:watch": "jest --watch --coverage",
-		"test:fuzz": "jest  --testMatch='**/*.fuzz.ts' --coverage=false --testTimeout=120000",
+		"test": "cross-env TZ='Europe/Paris' jest --coverage",
+		"test:watch": "cross-env TZ='Europe/Paris' jest --watch --coverage",
+		"test:fuzz": "cross-env TZ='Europe/Paris' jest --testMatch='**/*.fuzz.ts' --coverage=false --testTimeout=120000",
 		"prepare": "husky"
 	},
 	"dependencies": {
@@ -45,6 +45,7 @@
 		"@types/node": "22.13.11",
 		"@types/sinon": "17.0.4",
 		"chai": "5.2.0",
+		"cross-env": "7.0.3",
 		"eslint": "8.57.1",
 		"eslint-config-prettier": "9.1.0",
 		"eslint-plugin-jest": "27.9.0",

--- a/src/time.ts
+++ b/src/time.ts
@@ -74,6 +74,11 @@ export class CronTime {
 			this.utcOffset = utcOffset;
 		}
 
+		if (timeZone == null && utcOffset == null) {
+			const systemTimezone = Intl.DateTimeFormat().resolvedOptions().timeZone;
+			this.timeZone = systemTimezone;
+		}
+
 		if (source instanceof Date || source instanceof DateTime) {
 			this.source =
 				source instanceof Date ? DateTime.fromJSDate(source) : source;
@@ -115,6 +120,7 @@ export class CronTime {
 			this.realDate && this.source instanceof DateTime
 				? this.source
 				: DateTime.utc();
+
 		if (this.timeZone) {
 			date = date.setZone(this.timeZone);
 		}

--- a/tests/cron.test.ts
+++ b/tests/cron.test.ts
@@ -528,6 +528,23 @@ describe('cron', () => {
 			expect(callback).toHaveBeenCalledTimes(1);
 		});
 
+		// this test requires setting the TZ env variable
+		// to Europe/Paris to run correctly on CI
+		it('should use system timezone by default (issue #971)', () => {
+			const d = DateTime.fromISO('2025-03-28T00:00:00', {
+				zone: 'Europe/Paris'
+			}).toJSDate();
+			const clock = sinon.useFakeTimers(d.getTime());
+			const job = CronJob.from({
+				cronTime: '1 0 * * *',
+				onTick: callback,
+				start: true
+			});
+			clock.tick(60 * 60 * 1000);
+			job.stop();
+			expect(callback).toHaveBeenCalledTimes(1);
+		});
+
 		it('should test if timezone is valid.', () => {
 			expect(() => {
 				CronJob.from({

--- a/tests/cron.test.ts
+++ b/tests/cron.test.ts
@@ -668,7 +668,9 @@ describe('cron', () => {
 	});
 
 	it('should test start of month', () => {
-		const d = new Date(Date.UTC(2014, 12, 31, 23, 59, 59));
+		const d = DateTime.fromISO('2024-12-31T23:59:59', {
+			zone: 'Europe/Paris'
+		}).toJSDate();
 		const clock = sinon.useFakeTimers(d.getTime());
 
 		const job = new CronJob('0 0 0 1 * *', callback, null, true);
@@ -868,7 +870,10 @@ describe('cron', () => {
 	 * source: https://github.com/cronie-crond/cronie/blob/0d669551680f733a4bdd6bab082a0b3d6d7f089c/src/cronnext.c#L401-L403
 	 */
 	it('should work correctly for max match interval', () => {
-		const d = new Date(Date.UTC(2096, 2, 1));
+		const d = DateTime.fromISO('2096-03-01T00:00:00', {
+			zone: 'Europe/Paris'
+		}).toJSDate();
+
 		const clock = sinon.useFakeTimers(d.getTime());
 
 		const job = CronJob.from({

--- a/tests/cron.test.ts
+++ b/tests/cron.test.ts
@@ -14,7 +14,6 @@ describe('cron', () => {
 	});
 
 	afterEach(() => {
-		// eslint-disable-next-line jest/no-standalone-expect
 		expect.hasAssertions();
 		sinon.restore();
 	});
@@ -246,7 +245,6 @@ describe('cron', () => {
 			},
 			() => {
 				expect(callback).toHaveBeenCalledTimes(1);
-				clock.restore();
 				done();
 			},
 			true
@@ -265,7 +263,6 @@ describe('cron', () => {
 			},
 			() => {
 				expect(callback).toHaveBeenCalledTimes(1);
-				clock.restore();
 				done();
 			},
 			true
@@ -684,7 +681,6 @@ describe('cron', () => {
 
 		// 1 ms more than 31 days; jump over 2 firsts
 		clock.tick(31 * 24 * 60 * 60 * 1000 + 1);
-		clock.restore();
 		job.stop();
 
 		expect(callback).toHaveBeenCalledTimes(3);
@@ -889,7 +885,6 @@ describe('cron', () => {
 
 		// tick by 1 day
 		clock.tick(24 * 60 * 60 * 1000);
-		clock.restore();
 		job.stop();
 		expect(callback).toHaveBeenCalledTimes(1);
 	});
@@ -1064,17 +1059,15 @@ describe('cron', () => {
 
 	describe('nextDate(s)', () => {
 		it('should give the next date to run at', () => {
-			const clock = sinon.useFakeTimers();
+			sinon.useFakeTimers();
 			const job = new CronJob('* * * * * *', callback);
 			const d = Date.now();
 
 			expect(job.nextDate().toMillis()).toEqual(d + 1000);
-
-			clock.restore();
 		});
 
 		it('should give the next 5 dates to run at', () => {
-			const clock = sinon.useFakeTimers();
+			sinon.useFakeTimers();
 			const job = new CronJob('* * * * * *', callback);
 			const d = Date.now();
 
@@ -1085,17 +1078,11 @@ describe('cron', () => {
 				d + 4000,
 				d + 5000
 			]);
-
-			clock.restore();
 		});
 
 		it('should give an empty array when called without argument', () => {
-			const clock = sinon.useFakeTimers();
 			const job = new CronJob('* * * * * *', callback);
-
 			expect(job.nextDates()).toHaveLength(0);
-
-			clock.restore();
 		});
 	});
 
@@ -1207,7 +1194,6 @@ describe('cron', () => {
 		expect(handlerFunc).toHaveBeenLastCalledWith(new Error('Exception'));
 
 		job.stop();
-		clock.restore();
 	});
 
 	it('should log errors if errorHandler is NOT provided', () => {
@@ -1391,7 +1377,6 @@ describe('cron', () => {
 			clock.tick(1000);
 			expect(callback).toHaveBeenCalledTimes(1);
 
-			clock.restore();
 			job.stop();
 		});
 
@@ -1412,7 +1397,6 @@ describe('cron', () => {
 			clock.tick(1000);
 			expect(callback).toHaveBeenCalledTimes(1);
 
-			clock.restore();
 			job.stop();
 		});
 
@@ -1436,7 +1420,6 @@ describe('cron', () => {
 
 			expect(callback).toHaveBeenCalledTimes(6);
 
-			clock.restore();
 			job.stop();
 		});
 	});

--- a/tests/crontime.test.ts
+++ b/tests/crontime.test.ts
@@ -4,9 +4,9 @@ import { CronTime, validateCronExpression } from '../src';
 import { CronError } from '../src/errors';
 
 describe('crontime', () => {
-	// eslint-disable-next-line jest/no-standalone-expect
 	afterEach(() => {
 		expect.hasAssertions();
+		sinon.restore();
 	});
 
 	it('should test stars (* * * * * *)', () => {
@@ -655,39 +655,29 @@ describe('crontime', () => {
 	});
 
 	it('should accept 0 as a valid UTC offset', () => {
-		const clock = sinon.useFakeTimers();
-
+		sinon.useFakeTimers();
 		const cronTime = new CronTime('0 11 * * *', null, 0);
 		const expected = DateTime.local().plus({ hours: 11 }).toSeconds();
 		const actual = cronTime.sendAt().toSeconds();
-
 		expect(actual).toEqual(expected);
-
-		clock.restore();
 	});
 
 	it('should accept -120 as a valid UTC offset', () => {
-		const clock = sinon.useFakeTimers();
-
+		sinon.useFakeTimers();
 		const cronTime = new CronTime('0 11 * * *', null, -120);
 		const expected = DateTime.local().plus({ hours: 13 }).toSeconds();
 		const actual = cronTime.sendAt().toSeconds();
-
 		expect(actual).toEqual(expected);
-
-		clock.restore();
 	});
 
 	it('should detect real date in the past', () => {
 		const clock = sinon.useFakeTimers();
-
 		const d = new Date();
 		clock.tick(1000);
 		const time = new CronTime(d);
 		expect(() => {
 			time.sendAt();
 		}).toThrow();
-		clock.restore();
 	});
 
 	it('should throw when providing both exclusive parameters timeZone and utcOffset', () => {


### PR DESCRIPTION
## Description

Since v4.1.1, the timezone does not default to local system time anymore.

## Related Issue

Fixes #971 

## Motivation and Context

#971 

## How Has This Been Tested?

Added a test case with the appropriate environment variable setting.

## Screenshots (if appropriate):

## Types of changes

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] If my change introduces a breaking change, I have added a `!` after the type/scope in the title (see the Conventional Commits standard).
