### PR TITLE
feat!: remove `child_process` dependency for browser compatibility (#…

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 <p align="center">
   <img src="logo.svg" alt="cron for Node.js logo" height="150">
   <br />
-  <b>cron</b> is a robust tool for running jobs (functions or commands) on schedules defined using the cron syntax.
+  <b>cron</b> is a robust tool for running jobs (functions) on schedules defined using the cron syntax.
   <br />
   Perfect for tasks like data backups, notifications, and many more!
 </p>
@@ -20,7 +20,6 @@
 ## 🌟 Features
 
 - execute a function whenever your scheduled job triggers
-- execute a job external to the javascript process (like a system command) using `child_process`
 - use a Date or Luxon DateTime object instead of cron syntax as the trigger for your callback
 - use an additional slot for seconds (leaving it off will default to 0 and match the Unix behavior)
 

--- a/src/job.ts
+++ b/src/job.ts
@@ -1,9 +1,7 @@
-import { spawn } from 'child_process';
 import { CronError, ExclusiveParametersError } from './errors';
 import { CronTime } from './time';
 import {
 	CronCallback,
-	CronCommand,
 	CronContext,
 	CronJobParams,
 	CronOnCompleteCallback,
@@ -105,11 +103,8 @@ export class CronJob<OC extends CronOnCompleteCommand | null = null, C = null> {
 			this.unrefTimeout = unrefTimeout;
 		}
 
-		if (onComplete != null) {
-			// casting to the correct type since we just made sure that WithOnComplete<OC> = true
-			this.onComplete = this._fnWrap(
-				onComplete
-			) as WithOnComplete<OC> extends true ? CronOnCompleteCallback : undefined;
+		if (this.isCronOnCompleteCallback<OC>(onComplete)) {
+			this.onComplete = onComplete;
 		}
 
 		if (threshold != null) {
@@ -124,7 +119,7 @@ export class CronJob<OC extends CronOnCompleteCommand | null = null, C = null> {
 			this.runOnce = true;
 		}
 
-		this.addCallback(this._fnWrap(onTick));
+		this.addCallback(onTick);
 
 		if (runOnInit) {
 			this.lastExecution = new Date();
@@ -194,27 +189,12 @@ export class CronJob<OC extends CronOnCompleteCommand | null = null, C = null> {
 		}
 	}
 
-	private _fnWrap(cmd: CronCommand<C, boolean>): CronCallback<C, boolean> {
-		switch (typeof cmd) {
-			case 'function': {
-				return cmd;
-			}
-
-			case 'string': {
-				const [command, ...args] = cmd.split(' ');
-
-				return spawn.bind(undefined, command ?? cmd, args, {}) as () => void;
-			}
-
-			case 'object': {
-				return spawn.bind(
-					undefined,
-					cmd.command,
-					cmd.args ?? [],
-					cmd.options ?? {}
-				) as () => void;
-			}
-		}
+	private isCronOnCompleteCallback<OC>(
+		fn: unknown
+	): fn is WithOnComplete<OC> extends true
+		? CronOnCompleteCallback
+		: undefined {
+		return typeof fn === 'function';
 	}
 
 	addCallback(callback: CronCallback<C, WithOnComplete<OC>>) {

--- a/src/types/cron.types.ts
+++ b/src/types/cron.types.ts
@@ -1,4 +1,3 @@
-import { SpawnOptions } from 'child_process';
 import { DateTime } from 'luxon';
 import { CONSTRAINTS, TIME_UNITS_MAP } from '../constants';
 import { CronJob } from '../job';
@@ -45,19 +44,12 @@ export type CronCallback<C, WithOnCompleteBool extends boolean = false> = (
 
 export type CronOnCompleteCallback = () => void | Promise<void>;
 
-export type CronSystemCommand =
-	| string
-	| {
-			command: string;
-			args?: readonly string[] | null;
-			options?: SpawnOptions | null;
-	  };
+export type CronCommand<
+	C,
+	WithOnCompleteBool extends boolean = false
+> = CronCallback<C, WithOnCompleteBool>;
 
-export type CronCommand<C, WithOnCompleteBool extends boolean = false> =
-	| CronCallback<C, WithOnCompleteBool>
-	| CronSystemCommand;
-
-export type CronOnCompleteCommand = CronOnCompleteCallback | CronSystemCommand;
+export type CronOnCompleteCommand = CronOnCompleteCallback;
 
 export type WithOnComplete<OC> = OC extends null ? false : true;
 


### PR DESCRIPTION
…968)

<!--- Provide a general summary of your changes in the Title above (following the Conventional Commits standard) -->
<!-- More infos: https://www.conventionalcommits.org -->
<!-- Commit types:
https://github.com/insurgent-lab/conventional-changelog-preset#commit-types-->

## Description

<!--- Describe your changes in detail -->
BREAKING CHANGE: Removed the ability to execute system commands using string-based inputs. This eliminates the dependency on `child_process`, improving browser compatibility. Users relying on this functionality should migrate to executing commands manually within their own implementations.
## Related Issue

<!--- This project only accepts pull requests related to open issues --> <!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
#967
## Motivation and Context

<!--- Why is this change required? What problem does it solve? --> Running node-cron in a browser-based environment.
## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. --> <!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all
the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ X ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ X ] My code follows the code style of this project.
- [ X ] My change requires a change to the documentation.
- [ X ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ X ] All new and existing tests passed.
- [ X ] If my change introduces a breaking change, I have added a `!` after the type/scope in the title (see the Conventional Commits standard).

<!--- Provide a general summary of your changes in the Title above (following the Conventional Commits standard) -->
<!-- More infos: https://www.conventionalcommits.org -->
<!-- Commit types: https://github.com/insurgent-lab/conventional-changelog-preset#commit-types-->

## Description

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] If my change introduces a breaking change, I have added a `!` after the type/scope in the title (see the Conventional Commits standard).
