### PR TITLE
refactor: simplify exclusive timeZone/utcOffset parameter handling

### DIFF
--- a/src/job.ts
+++ b/src/job.ts
@@ -43,40 +43,10 @@ export class CronJob<OC extends CronOnCompleteCommand | null = null, C = null> {
 		onTick: CronJobParams<OC, C>['onTick'],
 		onComplete?: CronJobParams<OC, C>['onComplete'],
 		start?: CronJobParams<OC, C>['start'],
-		timeZone?: CronJobParams<OC, C>['timeZone'],
+		timeZone?: string | null,
 		context?: CronJobParams<OC, C>['context'],
 		runOnInit?: CronJobParams<OC, C>['runOnInit'],
-		utcOffset?: null,
-		unrefTimeout?: CronJobParams<OC, C>['unrefTimeout'],
-		waitForCompletion?: CronJobParams<OC, C>['waitForCompletion'],
-		errorHandler?: CronJobParams<OC, C>['errorHandler'],
-		name?: CronJobParams<OC, C>['name'],
-		threshold?: CronJobParams<OC, C>['threshold']
-	);
-	constructor(
-		cronTime: CronJobParams<OC, C>['cronTime'],
-		onTick: CronJobParams<OC, C>['onTick'],
-		onComplete?: CronJobParams<OC, C>['onComplete'],
-		start?: CronJobParams<OC, C>['start'],
-		timeZone?: null,
-		context?: CronJobParams<OC, C>['context'],
-		runOnInit?: CronJobParams<OC, C>['runOnInit'],
-		utcOffset?: CronJobParams<OC, C>['utcOffset'],
-		unrefTimeout?: CronJobParams<OC, C>['unrefTimeout'],
-		waitForCompletion?: CronJobParams<OC, C>['waitForCompletion'],
-		errorHandler?: CronJobParams<OC, C>['errorHandler'],
-		name?: CronJobParams<OC, C>['name'],
-		threshold?: CronJobParams<OC, C>['threshold']
-	);
-	constructor(
-		cronTime: CronJobParams<OC, C>['cronTime'],
-		onTick: CronJobParams<OC, C>['onTick'],
-		onComplete?: CronJobParams<OC, C>['onComplete'],
-		start?: CronJobParams<OC, C>['start'],
-		timeZone?: CronJobParams<OC, C>['timeZone'],
-		context?: CronJobParams<OC, C>['context'],
-		runOnInit?: CronJobParams<OC, C>['runOnInit'],
-		utcOffset?: CronJobParams<OC, C>['utcOffset'],
+		utcOffset?: number | null,
 		unrefTimeout?: CronJobParams<OC, C>['unrefTimeout'],
 		waitForCompletion?: CronJobParams<OC, C>['waitForCompletion'],
 		errorHandler?: CronJobParams<OC, C>['errorHandler'],
@@ -93,13 +63,7 @@ export class CronJob<OC extends CronOnCompleteCommand | null = null, C = null> {
 			throw new ExclusiveParametersError('timeZone', 'utcOffset');
 		}
 
-		if (timeZone != null) {
-			this.cronTime = new CronTime(cronTime, timeZone, null);
-		} else if (utcOffset != null) {
-			this.cronTime = new CronTime(cronTime, null, utcOffset);
-		} else {
-			this.cronTime = new CronTime(cronTime, timeZone, utcOffset);
-		}
+		this.cronTime = new CronTime(cronTime, timeZone ?? null, utcOffset ?? null);
 
 		if (unrefTimeout != null) {
 			this.unrefTimeout = unrefTimeout;
@@ -137,61 +101,23 @@ export class CronJob<OC extends CronOnCompleteCommand | null = null, C = null> {
 	static from<OC extends CronOnCompleteCommand | null = null, C = null>(
 		params: CronJobParams<OC, C>
 	) {
-		// runtime check for JS users
-		// eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
-		if (params.timeZone != null && params.utcOffset != null) {
-			throw new ExclusiveParametersError('timeZone', 'utcOffset');
-		}
-
-		if (params.timeZone != null) {
-			return new CronJob<OC, C>(
-				params.cronTime,
-				params.onTick,
-				params.onComplete,
-				params.start,
-				params.timeZone,
-				params.context,
-				params.runOnInit,
-				params.utcOffset,
-				params.unrefTimeout,
-				params.waitForCompletion,
-				params.errorHandler,
-				params.name,
-				params.threshold
-			);
-		} else if (params.utcOffset != null) {
-			return new CronJob<OC, C>(
-				params.cronTime,
-				params.onTick,
-				params.onComplete,
-				params.start,
-				null,
-				params.context,
-				params.runOnInit,
-				params.utcOffset,
-				params.unrefTimeout,
-				params.waitForCompletion,
-				params.errorHandler,
-				params.name,
-				params.threshold
-			);
-		} else {
-			return new CronJob<OC, C>(
-				params.cronTime,
-				params.onTick,
-				params.onComplete,
-				params.start,
-				params.timeZone,
-				params.context,
-				params.runOnInit,
-				params.utcOffset,
-				params.unrefTimeout,
-				params.waitForCompletion,
-				params.errorHandler,
-				params.name,
-				params.threshold
-			);
-		}
+		// The constructor's runtime check handles the exclusivity validation for JS users.
+		// The CronJobParams type enforces it at compile time for TS users.
+		return new CronJob<OC, C>(
+			params.cronTime,
+			params.onTick,
+			params.onComplete,
+			params.start,
+			('timeZone' in params ? params.timeZone : null) as string | null,
+			params.context,
+			params.runOnInit,
+			('utcOffset' in params ? params.utcOffset : null) as number | null,
+			params.unrefTimeout,
+			params.waitForCompletion,
+			params.errorHandler,
+			params.name,
+			params.threshold
+		);
 	}
 
 	private _fnWrap(cmd: CronCommand<C, boolean>): CronCallback<C, boolean> {

--- a/src/time.ts
+++ b/src/time.ts
@@ -43,18 +43,8 @@ export class CronTime {
 
 	constructor(
 		source: CronJobParams['cronTime'],
-		timeZone?: CronJobParams['timeZone'],
-		utcOffset?: null
-	);
-	constructor(
-		source: CronJobParams['cronTime'],
-		timeZone?: null,
-		utcOffset?: CronJobParams['utcOffset']
-	);
-	constructor(
-		source: CronJobParams['cronTime'],
-		timeZone?: CronJobParams['timeZone'],
-		utcOffset?: CronJobParams['utcOffset']
+		timeZone?: string | null,
+		utcOffset?: number | null
 	) {
 		// runtime check for JS users
 		if (timeZone != null && utcOffset != null) {


### PR DESCRIPTION
## Summary

Refactors the runtime check and typings for the mutually exclusive `timeZone` and `utcOffset` parameters in both `CronJob` and `CronTime` constructors.

## Problem

The `CronJob` class had **3 constructor overloads** (one with `utcOffset?: null`, one with `timeZone?: null`, and the implementation) to enforce that `timeZone` and `utcOffset` cannot both be set. The `CronTime` class had the same pattern. Meanwhile, `CronJobParams` already uses a **discriminated union with `never` types** to enforce this at compile time.

This resulted in:
- Redundant overloads that duplicate what the type system already enforces
- Redundant branching in `CronJob.from()` with 3 separate `new CronJob()` calls
- Unnecessary `if/else if/else` for `CronTime` instantiation

## Changes

### `src/job.ts`
- **Removed 2 constructor overloads**, keeping a single clean signature with `timeZone?: string | null` and `utcOffset?: number | null`
- **Simplified CronTime instantiation** from 3 branches to a single call: `new CronTime(cronTime, timeZone ?? null, utcOffset ?? null)`
- **Simplified `from()`** by removing the duplicated runtime check and 3-way branching — it now delegates directly to the constructor which already handles validation

### `src/time.ts`
- **Removed 2 constructor overloads**, keeping a single clean signature

## Backward Compatibility

- **Runtime behavior unchanged**: The runtime check (`if (timeZone != null && utcOffset != null) throw`) is preserved in both constructors for JS users
- **Type safety preserved**: `CronJobParams` still enforces exclusivity via the discriminated union for TS users
- No changes to public API or behavior

Result: **-106 lines, +22 lines** (net reduction of 84 lines of redundant code)

Fixes #704