### PR TITLE
feat(cron): add support for '?' syntax in cron expressions

### DIFF
--- a/src/time.ts
+++ b/src/time.ts
@@ -460,6 +460,26 @@ export class CronTime {
 			throw new CronError('Too many fields');
 		}
 
+		let questionMarkDate: DateTime<true> | DateTime<false> = DateTime.local();
+		if (this.timeZone) {
+			questionMarkDate = questionMarkDate.setZone(this.timeZone);
+		} else if (this.utcOffset !== undefined) {
+			const sign = this.utcOffset < 0 ? '-' : '+';
+			const offsetHours = Math.trunc(this.utcOffset / 60);
+			const offsetHoursStr = String(Math.abs(offsetHours)).padStart(2, '0');
+			const offsetMins = Math.abs(this.utcOffset - offsetHours * 60);
+			const offsetMinsStr = String(offsetMins).padStart(2, '0');
+
+			questionMarkDate = questionMarkDate.setZone(
+				`UTC${sign}${offsetHoursStr}:${offsetMinsStr}`
+			);
+		}
+
+		if (!questionMarkDate.isValid) {
+			throw new CronError('Invalid timezone or UTC offset for ? substitution');
+		}
+		const validQuestionMarkDate: DateTime<true> = questionMarkDate;
+
 		const unitsLen = units.length;
 		for (const unit of TIME_UNITS) {
 			const i = TIME_UNITS.indexOf(unit);
@@ -468,7 +488,31 @@ export class CronTime {
 			// this adds support for 5-digit standard cron syntax
 			const cur =
 				units[i - (TIME_UNITS_LEN - unitsLen)] ?? PARSE_DEFAULTS[unit];
-			this._parseField(cur, unit);
+			let value = cur;
+			if (value === '?') {
+				switch (unit) {
+					case 'second':
+						value = validQuestionMarkDate.second.toString();
+						break;
+					case 'minute':
+						value = validQuestionMarkDate.minute.toString();
+						break;
+					case 'hour':
+						value = validQuestionMarkDate.hour.toString();
+						break;
+					case 'dayOfMonth':
+						value = validQuestionMarkDate.day.toString();
+						break;
+					case 'month':
+						value = validQuestionMarkDate.month.toString();
+						break;
+					case 'dayOfWeek':
+						value = this._getWeekDay(validQuestionMarkDate).toString();
+						break;
+				}
+			}
+
+			this._parseField(value, unit);
 		}
 	}
 

--- a/tests/crontime.test.ts
+++ b/tests/crontime.test.ts
@@ -353,6 +353,50 @@ describe('crontime', () => {
 		});
 	});
 
+	describe('question mark syntax', () => {
+		it('should substitute ? with the initialization time', () => {
+			sinon.useFakeTimers(new Date('2024-04-08T10:15:30.000Z'));
+
+			const withQuestion = new CronTime('? ? ? ? ? ?');
+			const explicit = new CronTime('30 15 12 8 4 1');
+
+			// @ts-expect-error deleting for comparison purposes
+			delete withQuestion.source;
+			// @ts-expect-error deleting for comparison purposes
+			delete explicit.source;
+
+			expect(withQuestion).toEqual(explicit);
+		});
+
+		it('should support ? in standard 5-field cron syntax', () => {
+			sinon.useFakeTimers(new Date('2024-04-08T10:15:30.000Z'));
+
+			const withQuestion = new CronTime('? ? ? ? ?');
+			const explicit = new CronTime('0 15 12 8 4 1');
+
+			// @ts-expect-error deleting for comparison purposes
+			delete withQuestion.source;
+			// @ts-expect-error deleting for comparison purposes
+			delete explicit.source;
+
+			expect(withQuestion).toEqual(explicit);
+		});
+
+		it('should substitute ? using the cron timezone', () => {
+			sinon.useFakeTimers(new Date('2024-04-08T10:15:30.000Z'));
+
+			const cronTime = new CronTime('? ? ? ? ? ?', 'America/New_York');
+			expect(cronTime.toString()).toBe('30 15 6 8 4 1');
+		});
+
+		it('should substitute ? using utcOffset', () => {
+			sinon.useFakeTimers(new Date('2024-04-08T10:15:30.000Z'));
+
+			const cronTime = new CronTime('? ? ? ? ? ?', null, 330);
+			expect(cronTime.toString()).toBe('30 45 15 8 4 1');
+		});
+	});
+
 	describe('should throw an exception because `L` not supported', () => {
 		it('(* * * L * *)', () => {
 			expect(() => {
@@ -694,7 +738,8 @@ describe('validateCronExpression', () => {
 			'* * * * *',
 			'0 0 * * *',
 			'0 0 1 1 *',
-			'*/5 * * * *'
+			'*/5 * * * *',
+			'? ? * * * *'
 		];
 
 		validExpressions.forEach(expression => {


### PR DESCRIPTION
## Description

This PR adds support for the `?` syntax in cron expressions.

The `?` character is substituted with the initialization time value for the respective field (second, minute, hour, etc.) before standard parsing. The substitution is performed using a single timezone-aware snapshot to ensure consistency across all fields.

This implementation is minimal and integrates seamlessly with the existing parsing logic by resolving `?` before passing values to `_parseField()`.

---

## Related Issue

Closes #435

---

## Motivation and Context

This change is part of the extended cron syntax support discussed in #435.

The `?` syntax allows users to define cron expressions relative to the initialization time, making scheduling more flexible and expressive without requiring manual value calculation.

This PR focuses only on `?` support as a first step, with other extensions (`L`, `#`) to be implemented in follow-up PRs.

---

## How Has This Been Tested?

- Added unit tests covering:
  - Full `?` substitution across all fields
  - Mixed usage with fixed values
  - Support in both 5-field and 6-field cron syntax
  - Timezone-aware substitution using `timeZone`
  - Offset-based substitution using `utcOffset`

- Verified all tests pass using:
  - `npm test` (default Europe/Paris timezone)
  - Additional manual checks for correctness

---

## Screenshots (if appropriate):

N/A

---

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

---

## Checklist:

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [ ] If my change introduces a breaking change, I have added a `!` after the type/scope in the title.