### PR TITLE
feat(scheduler): add Scheduler for centralized cron job management

### DIFF
--- a/README.md
+++ b/README.md
@@ -274,6 +274,51 @@ day of week    0-7 (0 or 7 is Sunday, or use names)
 
 - `utcOffset`: [OPTIONAL] - Analogous to `utcOffset` from `CronJob` parameters.
 
+### Scheduler Class
+
+The `Scheduler` provides centralized management of multiple named `CronJob` instances. Registration is opt-in via `schedule()` or `register()` — passing `name` to `CronJob` alone does not register the job.
+
+A default singleton is exported as `scheduler`. Use `new Scheduler()` when you need an isolated registry (e.g. tests or workers).
+
+#### schedule
+
+`schedule(params)`: Creates a `CronJob`, registers it under `params.name`, then applies `runOnInit` and `start`. Accepts `ScheduleParams`, which extends `CronJobParams` with a required `name`.
+
+```javascript
+import { scheduler } from 'cron';
+
+scheduler.schedule({
+	name: 'backup',
+	cronTime: '0 2 * * *',
+	onTick: () => console.log('backup running'),
+	start: true,
+	timeZone: 'America/Sao_Paulo'
+});
+```
+
+#### register
+
+`register(name, job)`: Registers an existing `CronJob`. Sets `job.name` when unset. Throws if the job name mismatches or the name is already registered.
+
+#### Lifecycle Methods
+
+- `start(name)` / `stop(name)`: Start or stop a registered job.
+- `startAll()` / `stopAll()`: Start or stop all registered jobs.
+- `remove(name)`: Stop the job and remove it from the registry.
+- `unregister(name)`: Remove the job from the registry without stopping it.
+- `clear()`: Stop all jobs and empty the registry.
+
+#### Query Methods
+
+- `getJobNames()`: Returns all registered job names.
+- `getJob(name)`: Returns the `CronJob` instance, if registered.
+- `getJobInfo(name)`: Returns `{ name, executions, lastExecution, isActive, nextExecution, createdAt }`.
+- `getActiveJobs()` / `getInactiveJobs()`: Returns names of running or stopped jobs.
+- `getPending()`: Returns names of jobs that have never executed.
+- `nextJobs(count?)`: Returns a `Map` of upcoming execution dates per job.
+
+See the [examples/scheduler](examples/scheduler/) directory for runnable validation scripts.
+
 ## 💢 Gotchas
 
 - Both JS `Date` and Luxon `DateTime` objects don't guarantee millisecond precision due to computation delays. This module excludes millisecond precision for standard cron syntax but allows execution date specification through JS `Date` or Luxon `DateTime` objects. However, specifying a precise future execution time, such as adding a millisecond to the current time, may not always work due to these computation delays. It's observed that delays less than 4-5 ms might lead to inconsistencies. While we could limit all date granularity to seconds, we've chosen to allow greater precision but advise users of potential issues.

--- a/examples/scheduler.mjs
+++ b/examples/scheduler.mjs
@@ -1,0 +1,35 @@
+/**
+ * Exemplo simples do Scheduler.
+ *
+ * Para testes isolados com validação automática, veja:
+ *   examples/scheduler/
+ *
+ * Rodar todos: node examples/scheduler/run-all.mjs
+ */
+
+import { scheduler } from '../dist/index.js';
+
+const MAX = 5;
+let n = 0;
+
+scheduler.schedule({
+	name: 'example',
+	cronTime: '*/2 * * * * *',
+	onTick() {
+		n++;
+		console.log(`[${n}/${MAX}]`, scheduler.getJobInfo('example'));
+		if (n >= MAX) {
+			scheduler.remove('exemplo');
+			process.exit(0);
+		}
+	},
+	start: true,
+	timeZone: 'America/Sao_Paulo'
+});
+
+process.on('SIGINT', () => {
+	scheduler.clear();
+	process.exit(0);
+});
+
+console.log('Jobs:', scheduler.getJobNames());

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,6 +15,10 @@ export {
 	TimeUnit
 } from './types/cron.types';
 
+export { Scheduler, scheduler } from './scheduler';
+export type { ScheduleParams } from './scheduler';
+export type { RegistryEntry } from './registry';
+
 export const sendAt = (cronTime: string | Date | DateTime): DateTime =>
 	new CronTime(cronTime).sendAt();
 

--- a/src/registry.ts
+++ b/src/registry.ts
@@ -1,0 +1,58 @@
+import { CronJob } from './job';
+import { CronOnCompleteCommand } from './types/cron.types';
+
+interface RegistryEntry<
+	OC extends CronOnCompleteCommand | null = null,
+	C = null
+> {
+	job: CronJob<OC, C>;
+	createdAt: Date;
+	executions: number;
+}
+
+class JobRegistry {
+	private _jobs = new Map<string, RegistryEntry<any, any>>();
+
+	register<OC extends CronOnCompleteCommand | null = null, C = null>(
+		name: string,
+		job: CronJob<OC, C>
+	): void {
+		if (this._jobs.has(name)) {
+			throw new Error(`Job "${name}" is already registered`);
+		}
+
+		this._jobs.set(name, {
+			job,
+			createdAt: new Date(),
+			executions: 0
+		});
+	}
+
+	incrementExecutions(name: string): void {
+		const entry = this._jobs.get(name);
+		if (entry) entry.executions++;
+	}
+
+	getAll(): Map<string, RegistryEntry<any, any>> {
+		return new Map(this._jobs);
+	}
+
+	get(name: string): RegistryEntry<any, any> | undefined {
+		return this._jobs.get(name);
+	}
+
+	has(name: string): boolean {
+		return this._jobs.has(name);
+	}
+
+	remove(name: string): boolean {
+		return this._jobs.delete(name);
+	}
+
+	clear(): void {
+		this._jobs.clear();
+	}
+}
+
+export { JobRegistry };
+export type { RegistryEntry };

--- a/src/scheduler.ts
+++ b/src/scheduler.ts
@@ -1,0 +1,177 @@
+import { DateTime } from 'luxon';
+import { CronJob } from './job';
+import { JobRegistry } from './registry';
+import { CronJobParams, CronOnCompleteCommand } from './types/cron.types';
+
+export type ScheduleParams<
+	OC extends CronOnCompleteCommand | null = null,
+	C = null
+> = CronJobParams<OC, C> & { name: string };
+
+class Scheduler {
+	private registry = new JobRegistry();
+
+	/**
+	 * creates a CronJob and registers it under the given name.
+	 */
+	schedule<OC extends CronOnCompleteCommand | null = null, C = null>(
+		params: ScheduleParams<OC, C>
+	): CronJob<OC, C> {
+		const shouldStart = params.start ?? false;
+		const shouldRunOnInit = params.runOnInit ?? false;
+		const job = CronJob.from({ ...params, start: false, runOnInit: false });
+		this.register(params.name, job);
+
+		if (shouldRunOnInit) {
+			job.lastExecution = new Date();
+			void job.fireOnTick();
+		}
+
+		if (shouldStart) job.start();
+
+		return job;
+	}
+
+	/**
+	 * registers an existing CronJob. Registration is opt-in and never automatic.
+	 */
+	register<OC extends CronOnCompleteCommand | null = null, C = null>(
+		name: string,
+		job: CronJob<OC, C>
+	): this {
+		if (job.name != null && job.name !== name) {
+			throw new Error(
+				`Job name mismatch: expected "${name}", got "${job.name}"`
+			);
+		}
+
+		job.name = name;
+		this.registry.register(name, job);
+		job.addCallback(() => this.registry.incrementExecutions(name));
+		return this;
+	}
+
+	/**
+	 * removes a job from the registry without stopping it.
+	 */
+	unregister(name: string): this {
+		this.registry.remove(name);
+		return this;
+	}
+
+	/**
+	 * returns all registered job names.
+	 */
+	getJobNames(): string[] {
+		return [...this.registry.getAll().keys()];
+	}
+
+	/**
+	 * returns a specific job by name.
+	 */
+	getJob(name: string): CronJob | undefined {
+		return this.registry.get(name)?.job;
+	}
+
+	/**
+	 * returns detailed information about a specific job by name.
+	 */
+	getJobInfo(name: string) {
+		const entry = this.registry.get(name);
+		if (!entry) throw new Error(`Job "${name}" not found`);
+		return {
+			name,
+			executions: entry.executions,
+			lastExecution: entry.job.lastDate(),
+			isActive: entry.job.isActive,
+			nextExecution: entry.job.nextDate(),
+			createdAt: entry.createdAt
+		};
+	}
+
+	/**
+	 * returns names of jobs that are currently active (running).
+	 */
+	getActiveJobs(): string[] {
+		return [...this.registry.getAll().entries()]
+			.filter(([, entry]) => entry.job.isActive)
+			.map(([name]) => name);
+	}
+
+	/**
+	 * returns names of jobs that are currently inactive (stopped).
+	 */
+	getInactiveJobs(): string[] {
+		return [...this.registry.getAll().entries()]
+			.filter(([, entry]) => !entry.job.isActive)
+			.map(([name]) => name);
+	}
+
+	/**
+	 * returns names of jobs that have never been executed.
+	 */
+	getPending(): string[] {
+		return [...this.registry.getAll().entries()]
+			.filter(([, entry]) => entry.job.lastDate() === null)
+			.map(([name]) => name);
+	}
+
+	/**
+	 * returns the next execution dates for all registered jobs.
+	 */
+	nextJobs(count = 1): Map<string, DateTime | DateTime[]> {
+		const result = new Map<string, DateTime | DateTime[]>();
+
+		for (const [name, entry] of this.registry.getAll()) {
+			result.set(name, entry.job.nextDates(count));
+		}
+
+		return result;
+	}
+
+	start(name: string): this {
+		const entry = this.registry.get(name);
+		if (!entry) throw new Error(`Job "${name}" not found`);
+		entry.job.start();
+		return this;
+	}
+
+	stop(name: string): this {
+		const entry = this.registry.get(name);
+		if (!entry) throw new Error(`Job "${name}" not found`);
+		entry.job.stop();
+		return this;
+	}
+
+	startAll(): this {
+		for (const { job } of this.registry.getAll().values()) job.start();
+		return this;
+	}
+
+	stopAll(): this {
+		for (const { job } of this.registry.getAll().values()) job.stop();
+		return this;
+	}
+
+	/**
+	 * stops a job and removes it from the registry.
+	 */
+	remove(name: string): this {
+		const entry = this.registry.get(name);
+		if (entry) {
+			entry.job.stop();
+			this.registry.remove(name);
+		}
+		return this;
+	}
+
+	clear(): this {
+		for (const { job } of this.registry.getAll().values()) job.stop();
+		this.registry.clear();
+		return this;
+	}
+}
+
+const scheduler = new Scheduler();
+
+export { Scheduler, scheduler };

--- a/tests/scheduler.test.ts
+++ b/tests/scheduler.test.ts
@@ -1,0 +1,256 @@
+import sinon from 'sinon';
+import { CronJob, Scheduler, scheduler } from '../src';
+
+describe('Scheduler', () => {
+	let callback: jest.Mock;
+	let localScheduler: Scheduler;
+
+	beforeEach(() => {
+		callback = jest.fn();
+		localScheduler = new Scheduler();
+		scheduler.clear();
+	});
+
+	afterEach(() => {
+		expect.hasAssertions();
+		localScheduler.clear();
+		scheduler.clear();
+		sinon.restore();
+	});
+
+	describe('schedule', () => {
+		it('should create and register a job', () => {
+			const job = localScheduler.schedule({
+				name: 'test-job',
+				cronTime: '* * * * * *',
+				onTick: callback,
+				start: false
+			});
+
+			expect(job.name).toBe('test-job');
+			expect(localScheduler.getJob('test-job')).toBe(job);
+			expect(localScheduler.getJobNames()).toEqual(['test-job']);
+		});
+
+		it('should throw when scheduling a duplicate name', () => {
+			localScheduler.schedule({
+				name: 'dup',
+				cronTime: '* * * * * *',
+				onTick: callback,
+				start: false
+			});
+
+			expect(() =>
+				localScheduler.schedule({
+					name: 'dup',
+					cronTime: '* * * * * *',
+					onTick: callback,
+					start: false
+				})
+			).toThrow('Job "dup" is already registered');
+		});
+	});
+
+	describe('register', () => {
+		it('should register an existing job explicitly', () => {
+			const job = new CronJob('* * * * * *', callback, null, false);
+
+			localScheduler.register('my-job', job);
+
+			expect(job.name).toBe('my-job');
+			expect(localScheduler.getJob('my-job')).toBe(job);
+		});
+
+		it('should throw on name mismatch', () => {
+			const job = new CronJob(
+				'* * * * * *',
+				callback,
+				null,
+				false,
+				null,
+				null,
+				null,
+				null,
+				null,
+				null,
+				null,
+				'other-name'
+			);
+
+			expect(() => localScheduler.register('my-job', job)).toThrow(
+				'Job name mismatch'
+			);
+		});
+
+		it('should not auto-register jobs with a name only', () => {
+			new CronJob(
+				'* * * * * *',
+				callback,
+				null,
+				false,
+				null,
+				null,
+				null,
+				null,
+				null,
+				null,
+				null,
+				'standalone'
+			);
+
+			expect(localScheduler.getJob('standalone')).toBeUndefined();
+		});
+	});
+
+	describe('instance isolation', () => {
+		it('should keep registries independent between instances', () => {
+			const other = new Scheduler();
+
+			localScheduler.schedule({
+				name: 'local',
+				cronTime: '* * * * * *',
+				onTick: callback,
+				start: false
+			});
+
+			expect(localScheduler.getJobNames()).toEqual(['local']);
+			expect(other.getJobNames()).toEqual([]);
+
+			other.clear();
+		});
+	});
+
+	describe('execution tracking', () => {
+		it('should track executions and use job.lastDate() for lastExecution', () => {
+			const clock = sinon.useFakeTimers();
+
+			localScheduler.schedule({
+				name: 'counter',
+				cronTime: '* * * * * *',
+				onTick: callback,
+				start: true
+			});
+
+			expect(localScheduler.getJobInfo('counter').executions).toBe(0);
+			expect(localScheduler.getJobInfo('counter').lastExecution).toBeNull();
+			expect(localScheduler.getPending()).toEqual(['counter']);
+
+			clock.tick(1000);
+
+			const info = localScheduler.getJobInfo('counter');
+			expect(callback).toHaveBeenCalledTimes(1);
+			expect(info.executions).toBe(1);
+			expect(info.lastExecution).toBeInstanceOf(Date);
+			expect(localScheduler.getPending()).toEqual([]);
+
+			localScheduler.stop('counter');
+		});
+	});
+
+	describe('lifecycle', () => {
+		it('should start and stop individual jobs', () => {
+			const job = localScheduler.schedule({
+				name: 'lifecycle',
+				cronTime: '* * * * * *',
+				onTick: callback,
+				start: false
+			});
+
+			expect(job.isActive).toBe(false);
+			localScheduler.start('lifecycle');
+			expect(job.isActive).toBe(true);
+			localScheduler.stop('lifecycle');
+			expect(job.isActive).toBe(false);
+		});
+
+		it('should startAll and stopAll', () => {
+			localScheduler.schedule({
+				name: 'a',
+				cronTime: '* * * * * *',
+				onTick: callback,
+				start: false
+			});
+			localScheduler.schedule({
+				name: 'b',
+				cronTime: '* * * * * *',
+				onTick: callback,
+				start: false
+			});
+
+			localScheduler.startAll();
+			expect(localScheduler.getActiveJobs().sort()).toEqual(['a', 'b']);
+
+			localScheduler.stopAll();
+			expect(localScheduler.getInactiveJobs().sort()).toEqual(['a', 'b']);
+		});
+
+		it('should unregister without stopping the job', () => {
+			const job = localScheduler.schedule({
+				name: 'detach',
+				cronTime: '* * * * * *',
+				onTick: callback,
+				start: true
+			});
+
+			localScheduler.unregister('detach');
+
+			expect(localScheduler.getJob('detach')).toBeUndefined();
+			expect(job.isActive).toBe(true);
+
+			job.stop();
+		});
+
+		it('should remove by stopping and unregistering', () => {
+			const job = localScheduler.schedule({
+				name: 'remove-me',
+				cronTime: '* * * * * *',
+				onTick: callback,
+				start: true
+			});
+
+			localScheduler.remove('remove-me');
+
+			expect(localScheduler.getJob('remove-me')).toBeUndefined();
+			expect(job.isActive).toBe(false);
+		});
+
+		it('should clear all jobs', () => {
+			localScheduler.schedule({
+				name: 'x',
+				cronTime: '* * * * * *',
+				onTick: callback,
+				start: true
+			});
+			localScheduler.schedule({
+				name: 'y',
+				cronTime: '* * * * * *',
+				onTick: callback,
+				start: true
+			});
+
+			localScheduler.clear();
+
+			expect(localScheduler.getJobNames()).toEqual([]);
+		});
+	});
+
+	describe('queries', () => {
+		it('should return next execution dates', () => {
+			localScheduler.schedule({
+				name: 'next',
+				cronTime: '0 * * * * *',
+				onTick: callback,
+				start: false
+			});
+
+			const next = localScheduler.nextJobs(2);
+			expect(next.get('next')).toHaveLength(2);
+		});
+
+		it('should throw getJobInfo for unknown job', () => {
+			expect(() => localScheduler.getJobInfo('missing')).toThrow(
+				'Job "missing" not found'
+			);
+		});
+	});
+});


### PR DESCRIPTION
Introduce opt-in job registration via schedule() and register(). Each Scheduler instance owns an isolated JobRegistry for lifecycle control, status queries and graceful shutdown.

- add JobRegistry for per-instance job storage and execution counting
- add Scheduler with schedule, register, lifecycle and query methods
- export Scheduler singleton, ScheduleParams and RegistryEntry types
- add Jest tests and runnable examples under examples/scheduler/
- document Scheduler API in README

<!--- Provide a general summary of your changes in the Title above (following the Conventional Commits standard) -->
<!-- More infos: https://www.conventionalcommits.org -->
<!-- Commit types: https://github.com/insurgent-lab/conventional-changelog-preset#commit-types-->

## Description

Introduce opt-in job registration via `schedule()` and `register()`. Each `Scheduler` instance owns an isolated `JobRegistry` for lifecycle control, status queries and graceful shutdown.

- add `JobRegistry` for per-instance job storage and execution counting
- add `Scheduler` with `schedule`, `register`, lifecycle and query methods
- export `Scheduler` singleton, `ScheduleParams` and `RegistryEntry` types
- add Jest tests and runnable examples under `examples/scheduler/`
- document Scheduler API in README

### New API

**`Scheduler` / `scheduler`**
- `schedule(params)` — creates a `CronJob`, registers it, then applies `runOnInit` and `start`
- `register(name, job)` — registers an existing `CronJob` (opt-in, never automatic)
- Lifecycle: `start`, `stop`, `startAll`, `stopAll`, `remove`, `unregister`, `clear`
- Queries: `getJobNames`, `getJob`, `getJobInfo`, `getActiveJobs`, `getInactiveJobs`, `getPending`, `nextJobs`

**Design decisions**
- Registration is opt-in — passing `name` to `CronJob` alone does not register the job
- Each `Scheduler` instance has its own registry (isolated for tests and workers)
- `lastExecution` is derived from `job.lastDate()` to avoid duplicated metadata
- `remove()` stops and unregisters; `unregister()` only removes from the registry

## Related Issue

N/A — feature extension discussed and implemented locally. Happy to open a feature request issue if maintainers prefer tracking before merge.
URL: https://github.com/kelektiv/node-cron/issues/871

## Motivation and Context

The `node-cron` library is intentionally low-level: each `CronJob` is managed individually. In real applications with multiple scheduled tasks, developers typically reinvent a `Map` to track jobs, handle graceful shutdown, and expose health-check information.

This PR adds an optional management layer on top of the existing `CronJob` API without changing its behavior. Apps that only need a single job can continue using `CronJob` directly; apps with multiple jobs gain centralized lifecycle and query capabilities.

## How Has This Been Tested?

**Environment:** Node.js v20.12.2, Linux, `TZ=Europe/Paris` (Jest default for this repo)
**Unit tests** (`tests/scheduler.test.ts` — 14 cases):
npm run test -- tests/scheduler.test.ts

## Screenshots (if appropriate):

N/A — backend/library change, no UI.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [ ] If my change introduces a breaking change, I have added a `!` after the type/scope in the title (see the Conventional Commits standard).
