### PR TITLE
fix: don't advance lastDate() for ticks skipped by waitForCompletion

### DIFF
--- a/src/job.ts
+++ b/src/job.ts
@@ -127,7 +127,6 @@ export class CronJob<OC extends CronOnCompleteCommand | null = null, C = null> {
 		this.addCallback(this._fnWrap(onTick));
 
 		if (runOnInit) {
-			this.lastExecution = new Date();
 			void this.fireOnTick();
 		}
 
@@ -245,6 +244,10 @@ export class CronJob<OC extends CronOnCompleteCommand | null = null, C = null> {
 		// skip job if previous callback is still running
 		if (this.waitForCompletion && this._isCallbackRunning) return;
 
+		// record the moment the callback actually executes, so that lastDate()
+		// reflects the last real execution rather than the last tick check
+		// (ticks skipped above must not advance it). See #1048.
+		this.lastExecution = new Date();
 		this._isCallbackRunning = true;
 
 		// handle errors in synchronous and asynchronous callbacks
@@ -334,8 +337,6 @@ export class CronJob<OC extends CronOnCompleteCommand | null = null, C = null> {
 				setCronTimeout(timeout);
 			} else {
 				// we have arrived at the correct point in time.
-				this.lastExecution = new Date();
-
 				this._isActive = false;
 
 				// start before calling back so the callbacks have the ability to stop the cron job
@@ -364,7 +365,6 @@ export class CronJob<OC extends CronOnCompleteCommand | null = null, C = null> {
 				// execute immediately if within threshold
 				console.warn(`${message}. Executing immediately.`);
 
-				this.lastExecution = new Date();
 				void this.fireOnTick();
 			} else {
 				// skip job if beyond threshold

--- a/tests/cron.test.ts
+++ b/tests/cron.test.ts
@@ -1436,6 +1436,45 @@ describe('cron', () => {
 			expect(job.isCallbackRunning).toBe(false);
 			expect(job.isActive).toBe(false);
 		});
+
+		it('should not advance lastDate() for ticks skipped due to waitForCompletion (#1048)', async () => {
+			const clock = sinon.useFakeTimers();
+
+			const job = new CronJob(
+				'* * * * * *',
+				async () => {
+					await new Promise<void>(resolve => {
+						setTimeout(resolve, 1500);
+					});
+				},
+				null,
+				true,
+				null,
+				null,
+				false,
+				null,
+				false,
+				true // waitForCompletion: true
+			);
+
+			// first execution starts at 1000ms
+			await clock.tickAsync(1000);
+			expect(job.isCallbackRunning).toBe(true);
+			expect(job.lastDate()?.getTime()).toBe(1000);
+
+			// the tick at 2000ms is skipped because the callback is still
+			// running, so lastDate() must still reflect the 1000ms execution.
+			await clock.tickAsync(1000);
+			expect(job.isCallbackRunning).toBe(true);
+			expect(job.lastDate()?.getTime()).toBe(1000);
+
+			// first callback completes at 2500ms, next execution starts at 3000ms
+			await clock.tickAsync(1000);
+			expect(job.isCallbackRunning).toBe(true);
+			expect(job.lastDate()?.getTime()).toBe(3000);
+
+			job.stop();
+		});
 	});
 
 	describe('Daylight Saving Time', () => {


### PR DESCRIPTION
## Description

When `waitForCompletion` is enabled and a callback is still running, the scheduled tick is skipped early in `fireOnTick()`:

```ts
async fireOnTick() {
  // skip job if previous callback is still running
  if (this.waitForCompletion && this._isCallbackRunning) return;
  ...
}
```

However, `this.lastExecution = new Date()` was assigned at the call sites *before* invoking `fireOnTick()` (the normal timer path, plus the `runOnInit` and threshold-"execute immediately" paths). As a result `lastExecution` advanced on every tick check, even when the callback was skipped because the previous one was still running.

This means `lastDate()` / `lastExecution` reported the moment of the last *tick check* rather than the last real *execution*, which contradicts their documented meaning (`lastDate: Provides the last execution date.`) and is inconsistent with `nextDate()`/`nextDates()` which describe when an `onTick` actually activates.

## Related Issue

Closes #1048

## Motivation and Context

The fix moves the `lastExecution` assignment into `fireOnTick()`, placed right after the already-running guard, so it is only updated when a callback truly fires. The four call-site assignments are removed (the `runOnInit`, normal-tick, and threshold paths all call `fireOnTick()` immediately after, so firing behaviour is unchanged; the skipped path no longer advances the timestamp).

This keeps the existing documented semantics intact — confirmed by the pre-existing tests "should give the correct last execution date" and the #710 regression test, both of which still pass.

## How Has This Been Tested?

Added a regression test under the `waitForCompletion and job status tracking` suite. With a 1.5s callback on a `* * * * * *` schedule and `waitForCompletion: true`:

- t=1000ms: callback #1 starts → `lastDate()` is `1000`
- t=2000ms: tick is **skipped** (callback #1 still running) → `lastDate()` must still be `1000` (was `2000` before this fix)
- t=3000ms: callback #2 starts → `lastDate()` is `3000`

The test fails on `main` (`Expected: 1000, Received: 2000`) and passes with the fix. Full suite: `162 passed`. ESLint + Prettier clean, `tsc` build clean. Ran with `TZ='Europe/Paris'` as configured.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] If my change introduces a breaking change, I have added a `!` after the type/scope in the title (n/a — not a breaking change).