### PR TITLE
fix: OR day-of-month and day-of-week when a field is a full-coverage range

### DIFF
--- a/src/time.ts
+++ b/src/time.ts
@@ -41,6 +41,13 @@ export class CronTime {
 	private month: TimeUnitField<'month'> = {};
 	private dayOfWeek: TimeUnitField<'dayOfWeek'> = {};
 
+	// whether the raw day-of-month / day-of-week field was a literal "*".
+	// crontab(5) ORs the two day fields only when neither contains "*", so we
+	// must track the literal wildcard rather than infer it from cardinality (a
+	// full-coverage range like "1-31" has full cardinality yet is not "*").
+	private dayOfMonthWildcard = false;
+	private dayOfWeekWildcard = false;
+
 	constructor(
 		source: CronJobParams['cronTime'],
 		timeZone?: CronJobParams['timeZone'],
@@ -279,19 +286,19 @@ export class CronTime {
 				continue;
 			}
 
+			// crontab(5): when both day fields are restricted (neither is a
+			// literal "*"), the command runs when EITHER matches (OR). A field
+			// is restricted by the wildcard token, not by its cardinality, so a
+			// full-coverage range like "1-31" still counts as restricted.
 			if (
 				(!(date.day in this.dayOfMonth) &&
-					Object.keys(this.dayOfMonth).length !== 31 &&
+					!this.dayOfMonthWildcard &&
 					!(
-						this._getWeekDay(date) in this.dayOfWeek &&
-						Object.keys(this.dayOfWeek).length !== 7
+						this._getWeekDay(date) in this.dayOfWeek && !this.dayOfWeekWildcard
 					)) ||
 				(!(this._getWeekDay(date) in this.dayOfWeek) &&
-					Object.keys(this.dayOfWeek).length !== 7 &&
-					!(
-						date.day in this.dayOfMonth &&
-						Object.keys(this.dayOfMonth).length !== 31
-					))
+					!this.dayOfWeekWildcard &&
+					!(date.day in this.dayOfMonth && !this.dayOfMonthWildcard))
 			) {
 				date = date.plus({ days: 1 });
 				date = date.set({ hour: 0, minute: 0, second: 0 });
@@ -500,6 +507,15 @@ export class CronTime {
 				);
 			}
 		});
+
+		// record whether this day field was a literal "*" before we expand it,
+		// so the OR-semantics in getNextDateFrom can key off the wildcard token
+		// rather than the resulting cardinality
+		if (unit === 'dayOfMonth') {
+			this.dayOfMonthWildcard = value.includes('*');
+		} else if (unit === 'dayOfWeek') {
+			this.dayOfWeekWildcard = value.includes('*');
+		}
 
 		// "*" is a shortcut to [low-high] range for the field
 		value = value.replace(RE_WILDCARDS, `${low}-${high}`);

--- a/tests/crontime.test.ts
+++ b/tests/crontime.test.ts
@@ -718,4 +718,26 @@ describe('validateCronExpression', () => {
 			expect(validation.error).toBeInstanceOf(CronError);
 		});
 	});
+
+	it('should OR day-of-month and day-of-week when one field is a full-coverage range', () => {
+		// crontab(5): the union (OR) of the day fields applies only when both
+		// fields are restricted, i.e. neither field contains a literal "*".
+		// here "1-31" covers every day-of-month but is not "*", so dom and dow
+		// (monday) are both restricted and must be OR'd, firing every day.
+		const ct = new CronTime('0 0 12 1-31 * 1');
+		const start = DateTime.fromISO('2026-06-01T00:00:00.000Z', {
+			zone: 'utc'
+		});
+
+		const fired: number[] = [];
+		let cursor = start;
+		for (let i = 0; i < 4; i++) {
+			const next = ct.getNextDateFrom(cursor, 'utc');
+			fired.push(next.day);
+			cursor = next;
+		}
+
+		// verified against cron-parser 5.6.1 and croniter 6.2.2: jun 1, 2, 3, 4.
+		expect(fired).toEqual([1, 2, 3, 4]);
+	});
 });


### PR DESCRIPTION
## Problem

Per crontab(5):

> If both fields are restricted (i.e. do not contain the `*` character), the command will be run when either field matches.

The criterion is the literal `*` **character**, not whether the value-set covers every value. node-cron breaks this when one day field is a full-coverage range or step (`1-31`, `0-6`, `*/1`, `0,1,...,6`) instead of a literal `*`.

### Repro

Expression `0 0 12 1-31 * 1` (day-of-month = `1-31`, day-of-week = Monday), starting `2026-06-01T00:00:00Z`, UTC:

| Implementation | Result |
| --- | --- |
| node-cron (current) | Jun 1, 8, 15, 22 (only Mondays) — wrong |
| cron-parser 5.6.1 | Jun 1, 2, 3, 4 (every day) |
| croniter 6.2.2 | Jun 1, 2, 3, 4 (every day) |

Both `1-31` and `1` are restricted (neither is `*`), so the two day fields are OR'd and the job runs every day. node-cron applies AND and fires only on Mondays.

## Root cause

`getNextDateFrom` in `src/time.ts` decides whether each day field is "restricted" by cardinality:

```ts
Object.keys(this.dayOfMonth).length !== 31
Object.keys(this.dayOfWeek).length !== 7
```

That is a proxy for "the field is not `*`". A full-coverage range such as `1-31` has full cardinality yet is not `*`, so the proxy misclassifies it as a wildcard and falls back to AND. The parser never recorded whether the raw token was literally `*`.

## Fix

- Capture `dayOfMonthWildcard` / `dayOfWeekWildcard` at parse time, set when the raw field contains the `*` character (before the `*` to `low-high` expansion).
- Use those flags in the day-advance condition instead of the cardinality checks.

This keys the OR/AND decision on the `*` character exactly as crontab(5) specifies. `*/1` and other step-wildcards keep their existing wildcard treatment because they contain `*`.

## Tests

Added a `crontime` test asserting `0 0 12 1-31 * 1` fires Jun 1, 2, 3, 4 from `2026-06-01`. It fails on `main` (returns Jun 1, 8, 15, 22) and passes with the fix. Full suite stays green (162/162 under `TZ='Europe/Paris'`).