### PR TITLE
refactor(errors): dedupe timeZone/utcOffset exclusivity check

### DIFF
--- a/src/errors.ts
+++ b/src/errors.ts
@@ -5,3 +5,21 @@ export class ExclusiveParametersError extends CronError {
 		super(`You can't specify both ${param1} and ${param2}`);
 	}
 }
+
+/*
+ * runtime guard ensuring `timeZone` and `utcOffset` are not both provided.
+ *
+ * `timeZone` and `utcOffset` are mutually exclusive: TypeScript users get this
+ * enforced at compile time via the discriminated `CronJobParams` union, but
+ * plain JavaScript users (or `// @ts-ignore`d call sites) need a runtime check
+ * as well. Centralizing it here keeps the `CronJob` constructor, `CronJob.from`,
+ * and `CronTime` constructor all throwing the same error for the same input.
+ */
+export const assertExclusiveTimeZoneAndUtcOffset = (
+	timeZone?: string | null,
+	utcOffset?: number | null
+): void => {
+	if (timeZone != null && utcOffset != null) {
+		throw new ExclusiveParametersError('timeZone', 'utcOffset');
+	}
+};

--- a/src/job.ts
+++ b/src/job.ts
@@ -1,5 +1,5 @@
 import { spawn } from 'child_process';
-import { CronError, ExclusiveParametersError } from './errors';
+import { assertExclusiveTimeZoneAndUtcOffset, CronError } from './errors';
 import { CronTime } from './time';
 import {
 	CronCallback,
@@ -89,9 +89,7 @@ export class CronJob<OC extends CronOnCompleteCommand | null = null, C = null> {
 		this.errorHandler = errorHandler;
 
 		// runtime check for JS users
-		if (timeZone != null && utcOffset != null) {
-			throw new ExclusiveParametersError('timeZone', 'utcOffset');
-		}
+		assertExclusiveTimeZoneAndUtcOffset(timeZone, utcOffset);
 
 		if (timeZone != null) {
 			this.cronTime = new CronTime(cronTime, timeZone, null);
@@ -139,9 +137,7 @@ export class CronJob<OC extends CronOnCompleteCommand | null = null, C = null> {
 	) {
 		// runtime check for JS users
 		// eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
-		if (params.timeZone != null && params.utcOffset != null) {
-			throw new ExclusiveParametersError('timeZone', 'utcOffset');
-		}
+		assertExclusiveTimeZoneAndUtcOffset(params.timeZone, params.utcOffset);
 
 		if (params.timeZone != null) {
 			return new CronJob<OC, C>(

--- a/src/time.ts
+++ b/src/time.ts
@@ -11,7 +11,7 @@ import {
 	TIME_UNITS_LEN,
 	TIME_UNITS_MAP
 } from './constants';
-import { CronError, ExclusiveParametersError } from './errors';
+import { assertExclusiveTimeZoneAndUtcOffset, CronError } from './errors';
 import {
 	CronJobParams,
 	Ranges,
@@ -57,9 +57,7 @@ export class CronTime {
 		utcOffset?: CronJobParams['utcOffset']
 	) {
 		// runtime check for JS users
-		if (timeZone != null && utcOffset != null) {
-			throw new ExclusiveParametersError('timeZone', 'utcOffset');
-		}
+		assertExclusiveTimeZoneAndUtcOffset(timeZone, utcOffset);
 
 		if (timeZone) {
 			const dt = DateTime.fromObject({}, { zone: timeZone });

--- a/tests/errors.test.ts
+++ b/tests/errors.test.ts
@@ -1,0 +1,36 @@
+import {
+	assertExclusiveTimeZoneAndUtcOffset,
+	ExclusiveParametersError
+} from '../src/errors';
+
+describe('assertExclusiveTimeZoneAndUtcOffset', () => {
+	it('should throw an ExclusiveParametersError when both timeZone and utcOffset are provided', () => {
+		expect(() => {
+			assertExclusiveTimeZoneAndUtcOffset('America/Chicago', 120);
+		}).toThrow(ExclusiveParametersError);
+	});
+
+	it('should not throw when only timeZone is provided', () => {
+		expect(() => {
+			assertExclusiveTimeZoneAndUtcOffset('America/Chicago', null);
+		}).not.toThrow();
+	});
+
+	it('should not throw when only utcOffset is provided', () => {
+		expect(() => {
+			assertExclusiveTimeZoneAndUtcOffset(null, 120);
+		}).not.toThrow();
+	});
+
+	it('should not throw when neither timeZone nor utcOffset is provided', () => {
+		expect(() => {
+			assertExclusiveTimeZoneAndUtcOffset(null, null);
+		}).not.toThrow();
+	});
+
+	it('should not throw when both are omitted (undefined)', () => {
+		expect(() => {
+			assertExclusiveTimeZoneAndUtcOffset();
+		}).not.toThrow();
+	});
+});


### PR DESCRIPTION
**What**: Extracts the duplicated `timeZone`/`utcOffset` mutual-exclusivity runtime check into a single shared helper, `assertExclusiveTimeZoneAndUtcOffset()`, in `src/errors.ts`. It was previously copy-pasted verbatim in three places: the `CronJob` constructor, `CronJob.from()`, and the `CronTime` constructor.

**Why**: Per #704, this duplication is a maintenance risk — a future change to this rule (e.g. a new error message or an added parameter) would need to be applied in three separate spots, and it's easy to miss one.

**Testing**: Added `tests/errors.test.ts` with direct unit coverage of the new helper (all four boundary cases: both set, only one set either way, neither set). All existing tests continue to pass unmodified — this is a pure refactor with no behavior change. `npm run lint`, `npm run build`, and `npm run test` all pass locally.

Closes #704